### PR TITLE
Wrap exception as StatusException in completeObserver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,9 @@ lazy val grpcRuntime = project.in(file("scalapb-runtime-grpc"))
   .settings(
     name := "scalapb-runtime-grpc",
     libraryDependencies ++= Seq(
-      "io.grpc" % "grpc-stub" % grpcVersion
+      "io.grpc" % "grpc-stub" % grpcVersion,
+      "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+      "org.mockito" % "mockito-core" % "2.2.11" % "test"
     )
   )
 

--- a/e2e/src/main/protobuf/service.proto
+++ b/e2e/src/main/protobuf/service.proto
@@ -28,6 +28,9 @@ message Res4 {
   int32 b = 1;
 }
 
+message Req5 {}
+message Res5 {}
+
 service Service1 {
   // Computes string length
   rpc UnaryStringLength(Req1) returns (Res1) {}
@@ -40,4 +43,7 @@ service Service1 {
 
   // Doubles each Req4.a received.
   rpc BidiStreamingDoubler(stream Req4) returns (stream Res4) {}
+
+  // Throws a runtime exception.
+  rpc ThrowException(Req5) returns (Res5) {}
 }

--- a/e2e/src/main/scala/com/trueaccord/pb/Service1JavaImpl.scala
+++ b/e2e/src/main/scala/com/trueaccord/pb/Service1JavaImpl.scala
@@ -46,4 +46,9 @@ class Service1JavaImpl extends Service1ImplBase{
         observer.onNext(Res4.newBuilder.setB(request.getA * 2).build())
       }
     }
+
+
+  override def throwException(request: Req5, observer: StreamObserver[Res5]): Unit = {
+    observer.onError(new RuntimeException("Error!"))
+  }
 }

--- a/e2e/src/main/scala/com/trueaccord/pb/Service1ScalaImpl.scala
+++ b/e2e/src/main/scala/com/trueaccord/pb/Service1ScalaImpl.scala
@@ -47,4 +47,8 @@ class Service1ScalaImpl extends Service1 {
         observer.onNext(Res4(request.a * 2))
       }
     }
+
+  override def throwException(request: Req5): Future[Res5] = {
+    Future.failed(new RuntimeException("Error!"))
+  }
 }

--- a/e2e/src/test/scala/GrpcServiceJavaServerSpec.scala
+++ b/e2e/src/test/scala/GrpcServiceJavaServerSpec.scala
@@ -62,6 +62,17 @@ class GrpcServiceJavaServerSpec extends GrpcServiceSpecBase {
         Await.result(future, 2.seconds).map(_.b) must be(Vector(22, 6, 12))
       }
     }
+
+    it("should wrap an exception as a StatusRuntimeException") {
+      withJavaServer { channel =>
+        val client = Service1GrpcScala.stub(channel)
+
+        intercept[io.grpc.StatusRuntimeException] {
+          Await.result( client.throwException( Req5() ), 2.seconds )
+        }
+      }
+    }
+
   }
 
 }

--- a/e2e/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -98,6 +98,16 @@ class GrpcServiceScalaServerSpec extends GrpcServiceSpecBase {
           Await.result(future, 2.seconds).map(_.b) must be(Vector(22, 6, 12))
         }
       }
+
+      it("should wrap an exception as a StatusRuntimeException") {
+        withScalaServer { channel =>
+          val client = Service1GrpcScala.stub(channel)
+
+          intercept[io.grpc.StatusRuntimeException] {
+            Await.result( client.throwException( Req5() ), 2.seconds )
+          }
+        }
+      }
     }
   }
 }

--- a/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
@@ -1,9 +1,10 @@
 package com.trueaccord.scalapb.grpc
 
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import io.grpc.{Status, StatusException}
 import io.grpc.stub.StreamObserver
 
-import scala.concurrent.{Promise, Future}
+import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 object Grpc {
@@ -20,7 +21,11 @@ object Grpc {
     case scala.util.Success(value) =>
       observer.onNext(value)
       observer.onCompleted()
-    case scala.util.Failure(error) =>
-      observer.onError(error)
+    case scala.util.Failure(s: StatusException) =>
+      observer.onError(s)
+    case scala.util.Failure(e) =>
+      observer.onError(
+        Status.INTERNAL.withDescription(e.getMessage).withCause(e).asException()
+      )
   }
 }

--- a/scalapb-runtime-grpc/src/test/scala/com/trueaccord/scalapb/grpc/GrpcSpec.scala
+++ b/scalapb-runtime-grpc/src/test/scala/com/trueaccord/scalapb/grpc/GrpcSpec.scala
@@ -1,0 +1,21 @@
+package com.trueaccord.scalapb.grpc
+
+import io.grpc.StatusException
+import io.grpc.stub.StreamObserver
+import org.mockito.{ ArgumentMatchers, Mockito }
+import org.scalatest.FlatSpec
+import org.scalatest.mockito.MockitoSugar
+
+import scala.util.Failure
+
+class GrpcSpec extends FlatSpec with MockitoSugar {
+
+  "Complete observer" should "wrap an exception as a StatusException on failure" in {
+    val observer = mock[StreamObserver[_]]
+
+    Grpc.completeObserver(observer)(Failure(new RuntimeException("Error!")))
+
+    Mockito.verify(observer).onError(ArgumentMatchers.any(classOf[StatusException]))
+  }
+
+}


### PR DESCRIPTION
gRPC's StreamObserver expects to receive StatusException on failure in order to respond with an error message to a client.

See Javadoc here: https://github.com/grpc/grpc-java/blob/master/stub/src/main/java/io/grpc/stub/StreamObserver.java#L76

I've also added an e2e test to test how it interacts with a client. Let me know if there's anything you want me to change or add.