### PR TITLE
enable wrapper support by default

### DIFF
--- a/compiler-plugin/src/main/java/com/trueaccord/scalapb/Scalapb.java
+++ b/compiler-plugin/src/main/java/com/trueaccord/scalapb/Scalapb.java
@@ -205,7 +205,7 @@ public final class Scalapb {
       import_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       preamble_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       singleFile_ = false;
-      primitiveWrappers_ = false;
+      primitiveWrappers_ = true;
     }
 
     @java.lang.Override


### PR DESCRIPTION
i don't expect you to merge this without a chat, but the way you have designed to enable wrappers using options breaks some C# based proto generators, because it doesn't agree with proto3/proto2 mix matches with descriptors. So there-for this was the quickest thing for me to do to get things running, doing this have removed the need to include scalapb.proto file and allows me to have wrapper enabled code. Thank you :) 