### PR TITLE
Add service constructor

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
@@ -5,35 +5,82 @@ import com.trueaccord.scalapb.compiler.FunctionalPrinter.PrinterEndo
 
 final class GrpcServiceIFacePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
   
-  private[this] def service(reqTypeParam: String, repTypeParam: String): String = s"Service[$reqTypeParam, $repTypeParam]"
+  private[this] def unaryService(reqTypeParam: String, repTypeParam: String): String = s"Service[$reqTypeParam, $repTypeParam]"
 
-  private[this] val serviceTypeAlias: String = s"type Service[Req, Rep] = Req => scala.concurrent.Future[Rep]"
+  private[this] def clientStreamingService(reqTypeParam: String, repTypeParam: String): String = s"ClientStreamingService[$repTypeParam, $reqTypeParam]"
 
-  private[this] def serviceParamSignature(method: MethodDescriptor) =
-    s"${method.name}: ${service(method.scalaIn, method.scalaOut)}"
+  private[this] def serverStreamingService(reqTypeParam: String, reqTypeParam2: String): String = s"ServerStreamingService[$reqTypeParam, $reqTypeParam2]"
 
+  private[this] def bidirectionalService(reqTypeParam: String, repTypeParam: String): String = s"BidirectionalService[$repTypeParam, $reqTypeParam]"
+
+  private[this] val unaryServiceTypeAlias: String = s"type Service[Req, Rep] = Req => scala.concurrent.Future[Rep]"
+
+  private[this] val clientStreamingServiceTypeAlias: String = "type ClientStreamingService[Req, Rep] = _root_.io.grpc.stub.StreamObserver[Req] => _root_.io.grpc.stub.StreamObserver[Rep]"
+
+  private[this] val serverStreamingServiceTypeAlias: String = "type ServerStreamingService[Req, Req2] = (Req, _root_.io.grpc.stub.StreamObserver[Req2]) => Unit"
+
+  private[this] val bidirectionalServiceTypeAlias: String = "type BidirectionalService[Req, Rep] = _root_.io.grpc.stub.StreamObserver[Req] => _root_.io.grpc.stub.StreamObserver[Rep]"
+
+  private[this] def functionTypeSig(from: String, to: String): String = s"$from => $to"
+
+  private[this] def observer(typeParam: String): String = s"$streamObserver[$typeParam]"
+
+  private[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
+
+
+  private[this] def serviceParam(method: MethodDescriptor) = s"${method.name}: ${serviceTypeSignature(method)}"
+
+  private[this] def serviceTypeSignature(method: MethodDescriptor) = 
+    (method.streamType match {
+      case StreamType.Unary =>
+        s"${unaryService(method.scalaIn, method.scalaOut)}"
+      case StreamType.ClientStreaming =>
+        s"${clientStreamingService(method.scalaIn, method.scalaOut)}"
+      case StreamType.ServerStreaming =>
+        s"${serverStreamingService(method.scalaIn, method.scalaOut)}"
+      case StreamType.Bidirectional =>
+        s"${bidirectionalService(method.scalaIn, method.scalaOut)}"
+    })
   private[this] def methodAlias(method: MethodDescriptor) = s"${method.name}Alias"
-
+  
   private[this] def serviceAliasDefinition(method: MethodDescriptor) =
-    s"val ${methodAlias(method)}: ${service(method.scalaIn, method.scalaOut)} = ${method.name}"
+    s"val ${methodAlias(method)}: ${serviceTypeSignature(method)} = ${method.name}"
 
   private[this] def serviceMethodSignature(method: MethodDescriptor) = 
-    s"def ${method.name}(request: ${method.scalaIn}): scala.concurrent.Future[${method.scalaOut}]"
+    s"def ${method.name}" + (method.streamType match {
+      case StreamType.Unary =>
+        s"(request: ${method.scalaIn}): scala.concurrent.Future[${method.scalaOut}]"
+      case StreamType.ClientStreaming =>
+        s"(responseObserver: ${observer(method.scalaOut)}): ${observer(method.scalaIn)}"
+      case StreamType.ServerStreaming =>
+        s"(request: ${method.scalaIn}, responseObserver: ${observer(method.scalaOut)}): Unit"
+      case StreamType.Bidirectional =>
+        s"(responseObserver: ${observer(method.scalaOut)}): ${observer(method.scalaIn)}"
+    })
 
-  private[this] def serviceInterfaceMethodsDefinition(method: MethodDescriptor) =
-    s"${serviceMethodSignature(method)} = ${methodAlias(method)}(request)"
+  private[this] def serviceInterfaceMethodDefinition(method: MethodDescriptor) = 
+    s"${serviceMethodSignature(method)} = " + (method.streamType match {
+      case StreamType.Unary =>
+        s"${methodAlias(method)}(request)"
+      case StreamType.ClientStreaming =>
+         s"${methodAlias(method)}(responseObserver)"
+      case StreamType.ServerStreaming =>
+         s"${methodAlias(method)}(request, responseObserver)"
+      case StreamType.Bidirectional =>
+         s"${methodAlias(method)}(responseObserver)"
+    })
 
   private[this] def serviceImport = s"import ${service.objectName}._"
 
   private[this] def serviceIFaceConstructor: PrinterEndo = {
-    val params: String = service.methods.map(m => serviceParamSignature(m)).mkString(",\n")
+    val params: String = service.methods.map(m => serviceParam(m)).mkString(",\n")
 
     val aliases: PrinterEndo = { p =>
       p.seq(service.methods.map(m => serviceAliasDefinition(m)))
     }
 
     val implementations: PrinterEndo = { p =>
-      p.seq(service.methods.map(m => serviceInterfaceMethodsDefinition(m)))
+      p.seq(service.methods.map(m => serviceInterfaceMethodDefinition(m)))
     }
     p =>
     p
@@ -60,10 +107,14 @@ final class GrpcServiceIFacePrinter(service: ServiceDescriptor, override val par
       .newline
       .add(s"object ${service.objectName}ServiceI {")
       .indent
-      .add(serviceTypeAlias)
+      .add(unaryServiceTypeAlias)
+      .add(clientStreamingServiceTypeAlias)
+      .add(serverStreamingServiceTypeAlias)
+      .add(bidirectionalServiceTypeAlias)
       .newline
       .call(serviceIFaceConstructor)
       .outdent
       .add("}")
   }
+
 }

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
@@ -58,7 +58,7 @@ final class GrpcServiceIFacePrinter(service: ServiceDescriptor, override val par
       .add("package " + service.getFile.scalaPackageName)
       .add(serviceImport)
       .newline
-      .add(s"object ${service.objectName}IFace {")
+      .add(s"object ${service.objectName}ServiceI {")
       .indent
       .add(serviceTypeAlias)
       .newline

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServiceIFacePrinter.scala
@@ -1,0 +1,69 @@
+package com.trueaccord.scalapb.compiler
+
+import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import com.trueaccord.scalapb.compiler.FunctionalPrinter.PrinterEndo
+
+final class GrpcServiceIFacePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
+  
+  private[this] def service(reqTypeParam: String, repTypeParam: String): String = s"Service[$reqTypeParam, $repTypeParam]"
+
+  private[this] val serviceTypeAlias: String = s"type Service[Req, Rep] = Req => scala.concurrent.Future[Rep]"
+
+  private[this] def serviceParamSignature(method: MethodDescriptor) =
+    s"${method.name}: ${service(method.scalaIn, method.scalaOut)}"
+
+  private[this] def methodAlias(method: MethodDescriptor) = s"${method.name}Alias"
+
+  private[this] def serviceAliasDefinition(method: MethodDescriptor) =
+    s"val ${methodAlias(method)}: ${service(method.scalaIn, method.scalaOut)} = ${method.name}"
+
+  private[this] def serviceMethodSignature(method: MethodDescriptor) = 
+    s"def ${method.name}(request: ${method.scalaIn}): scala.concurrent.Future[${method.scalaOut}]"
+
+  private[this] def serviceInterfaceMethodsDefinition(method: MethodDescriptor) =
+    s"${serviceMethodSignature(method)} = ${methodAlias(method)}(request)"
+
+  private[this] def serviceImport = s"import ${service.objectName}._"
+
+  private[this] def serviceIFaceConstructor: PrinterEndo = {
+    val params: String = service.methods.map(m => serviceParamSignature(m)).mkString(",\n")
+
+    val aliases: PrinterEndo = { p =>
+      p.seq(service.methods.map(m => serviceAliasDefinition(m)))
+    }
+
+    val implementations: PrinterEndo = { p =>
+      p.seq(service.methods.map(m => serviceInterfaceMethodsDefinition(m)))
+    }
+    p =>
+    p
+      .add(s"def apply(")
+      .indent
+      .add(params)
+      .outdent
+      .add(s") = {")
+      .indent
+      .call(aliases)
+      .add(s"new ${service.name} {")
+      .indent
+      .call(implementations)
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
+  }
+
+  def printService(printer: FunctionalPrinter): FunctionalPrinter = {
+    printer
+      .add("package " + service.getFile.scalaPackageName)
+      .add(serviceImport)
+      .newline
+      .add(s"object ${service.objectName}IFace {")
+      .indent
+      .add(serviceTypeAlias)
+      .newline
+      .call(serviceIFaceConstructor)
+      .outdent
+      .add("}")
+  }
+}

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
@@ -7,10 +7,6 @@ import scala.collection.JavaConverters._
 final class GrpcServicePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
   private[this] def observer(typeParam: String): String = s"$streamObserver[$typeParam]"
 
-  private[this] def service(reqTypeParam: String, repTypeParam: String): String = s"Service[$reqTypeParam, $repTypeParam]"
-
-  private[this] val serviceTypeAlias: String = s"type Service[Req, Rep] = Req => scala.concurrent.Future[Rep]"
-
   private[this] def serviceMethodSignature(method: MethodDescriptor) = {
     s"def ${method.name}" + (method.streamType match {
       case StreamType.Unary =>
@@ -24,9 +20,6 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
     })
   }
 
-  private[this] def serviceParamSignature(method: MethodDescriptor) =
-    s"${method.name}: ${service(method.scalaIn, method.scalaOut)}"
-
   private[this] def blockingMethodSignature(method: MethodDescriptor) = {
     s"def ${method.name}" + (method.streamType match {
       case StreamType.Unary =>
@@ -35,42 +28,6 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
         s"(request: ${method.scalaIn}): scala.collection.Iterator[${method.scalaOut}]"
       case _ => throw new IllegalArgumentException("Invalid method type.")
     })
-  }
-
-  private[this] def methodAlias(method: MethodDescriptor) = s"${method.name}Alias"
-
-  private[this] def serviceAliasDefinition(method: MethodDescriptor) =
-    s"val ${methodAlias(method)}: ${service(method.scalaIn, method.scalaOut)} = ${method.name}"
-
-  private[this] def serviceInterfaceMethodsDefinition(method: MethodDescriptor) =
-    s"${serviceMethodSignature(method)} = ${methodAlias(method)}(request)"
-
-  private[this] def serviceInterface: PrinterEndo = {
-    val params: String = service.methods.map(m => serviceParamSignature(m)).mkString(",\n")
-
-    val aliases: PrinterEndo = { p =>
-      p.seq(service.methods.map(m => serviceAliasDefinition(m)))
-    }
-
-    val implementations: PrinterEndo = { p =>
-      p.seq(service.methods.map(m => serviceInterfaceMethodsDefinition(m)))
-    }
-    p =>
-    p
-      .add(s"def apply(")
-      .indent
-      .add(params)
-      .outdent
-      .add(s") = {")
-      .indent
-      .call(aliases)
-      .add(s"new ${service.name} {")
-      .indent
-      .call(implementations)
-      .outdent
-      .add("}")
-      .outdent
-      .add("}")
   }
 
   private[this] def serviceTrait: PrinterEndo = {
@@ -286,10 +243,8 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
       "",
       s"object ${service.objectName} {")
     .indent
-    .add(serviceTypeAlias)
     .call(service.methods.map(methodDescriptor): _*)
     .call(serviceTrait)
-    .call(serviceInterface)
     .newline
     .call(serviceTraitCompanion)
     .newline

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
@@ -4,10 +4,10 @@ import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import com.trueaccord.scalapb.compiler.FunctionalPrinter.PrinterEndo
 import scala.collection.JavaConverters._
 
-final class GrpcServicePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
-  private[this] def observer(typeParam: String): String = s"$streamObserver[$typeParam]"
+class GrpcServicePrinterCommons(override val params: GeneratorParams) extends DescriptorPimps {
+  protected[this] def observer(typeParam: String): String = s"$streamObserver[$typeParam]"
 
-  private[this] def serviceMethodSignature(method: MethodDescriptor) = {
+  protected[this] def serviceMethodSignature(method: MethodDescriptor) = {
     s"def ${method.name}" + (method.streamType match {
       case StreamType.Unary =>
         s"(request: ${method.scalaIn}): scala.concurrent.Future[${method.scalaOut}]"
@@ -19,6 +19,11 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
         s"(responseObserver: ${observer(method.scalaOut)}): ${observer(method.scalaIn)}"
     })
   }
+  protected[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
+
+}
+
+final class GrpcServicePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends GrpcServicePrinterCommons(params) {
 
   private[this] def blockingMethodSignature(method: MethodDescriptor) = {
     s"def ${method.name}" + (method.streamType match {
@@ -75,7 +80,6 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
   private[this] val callOptions = "_root_.io.grpc.CallOptions"
 
   private[this] val abstractStub = "_root_.io.grpc.stub.AbstractStub"
-  private[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
 
   private[this] val serverCalls = "_root_.io.grpc.stub.ServerCalls"
   private[this] val clientCalls = "_root_.io.grpc.stub.ClientCalls"

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -1120,7 +1120,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         val p = new GrpcServiceIFacePrinter(service, params)
         val code = p.printService(FunctionalPrinter()).result()
         val b = CodeGeneratorResponse.File.newBuilder()
-        b.setName(file.scalaDirectory + "/" + s"${service.objectName}IFace.scala")
+        b.setName(file.scalaDirectory + "/" + s"${service.objectName}ServiceI.scala")
         b.setContent(code)
         b.build
       }

--- a/compiler-plugin/src/main/scala/scalapb/package.scala
+++ b/compiler-plugin/src/main/scala/scalapb/package.scala
@@ -5,6 +5,7 @@ package object scalapb {
     flatPackage: Boolean = false,
     javaConversions: Boolean = false,
     grpc: Boolean = true,
+    grpcServiceIFace: Boolean = true,
     singleLineToString: Boolean = false): (JvmGenerator, Seq[String]) =
     (JvmGenerator(
       "scala",
@@ -13,6 +14,7 @@ package object scalapb {
         "flat_package" -> flatPackage,
         "java_conversions" -> javaConversions,
         "grpc" -> grpc,
+        "grpc_service_interface" -> grpcServiceIFace,
         "single_line_to_string" -> singleLineToString
       ).collect { case (name, v) if v => name })
 }

--- a/proptest/src/test/scala/GeneratedCodeSpec.scala
+++ b/proptest/src/test/scala/GeneratedCodeSpec.scala
@@ -39,6 +39,7 @@ class GeneratedCodeSpec extends PropSpec with GeneratorDrivenPropertyChecks with
               val companion = schema.scalaObject(message)
               val scalaProto = companion.fromAscii(messageValue.toAscii)
               val scalaBytes = scalaProto.toByteArray
+
               // Parsing in Scala the serialized bytes should give the same object.
               val scalaParsedFromBytes = companion.parseFrom(scalaBytes)
               scalaParsedFromBytes.toString should be(scalaProto.toString)
@@ -87,6 +88,7 @@ class GeneratedCodeSpec extends PropSpec with GeneratorDrivenPropertyChecks with
 
               val jsonRep = com.trueaccord.scalapb.json.JsonFormat.toJsonString(scalaProto)
               com.trueaccord.scalapb.json.JsonFormat.fromJsonString(jsonRep)(companion.asInstanceOf[GeneratedMessageCompanion[T] forSome {type T <: GeneratedMessage with ScalaPBMessage[T] }]) should be(scalaProto)
+
             } catch {
               case e: Exception =>
                 println(e.printStackTrace)

--- a/proptest/src/test/scala/GeneratedCodeSpec.scala
+++ b/proptest/src/test/scala/GeneratedCodeSpec.scala
@@ -39,7 +39,6 @@ class GeneratedCodeSpec extends PropSpec with GeneratorDrivenPropertyChecks with
               val companion = schema.scalaObject(message)
               val scalaProto = companion.fromAscii(messageValue.toAscii)
               val scalaBytes = scalaProto.toByteArray
-
               // Parsing in Scala the serialized bytes should give the same object.
               val scalaParsedFromBytes = companion.parseFrom(scalaBytes)
               scalaParsedFromBytes.toString should be(scalaProto.toString)
@@ -88,7 +87,6 @@ class GeneratedCodeSpec extends PropSpec with GeneratorDrivenPropertyChecks with
 
               val jsonRep = com.trueaccord.scalapb.json.JsonFormat.toJsonString(scalaProto)
               com.trueaccord.scalapb.json.JsonFormat.fromJsonString(jsonRep)(companion.asInstanceOf[GeneratedMessageCompanion[T] forSome {type T <: GeneratedMessage with ScalaPBMessage[T] }]) should be(scalaProto)
-
             } catch {
               case e: Exception =>
                 println(e.printStackTrace)


### PR DESCRIPTION
Expose service interface similar to finagle. This allows for services to be composed and filters to be applied:

```scala
  val stutter = new Filter[HelloRequest, HelloReply] {
    def apply(r: HelloRequest, s: Service[HelloRequest, HelloReply]): Service[HelloRequest, HelloReply] =
      r => s(r.copy(name = r.name * 2))
  }
  val qadrupleGreeter = stutter andThen stutter andThen greeter
  val sayHelloService = GreeterGrpcIFace(
    sayHello = qadrupleGreeter
  )

```
Reference: https://twitter.github.io/scrooge/Finagle.html