### PR TITLE
add collection_type settings

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
@@ -158,7 +158,7 @@ trait DescriptorPimps {
 
     def typeCategory(base: String): String = {
       if (supportsPresence) s"scala.Option[$base]"
-      else if (fd.isRepeated) s"scala.collection.Seq[$base]"
+      else if (fd.isRepeated) s"${params.collectionType}[$base]"
       else base
     }
 

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 
 case class GeneratorParams(
   javaConversions: Boolean = false, flatPackage: Boolean = false,
-  grpc: Boolean = false, singleLineToString: Boolean = false)
+  grpc: Boolean = false, singleLineToString: Boolean = false, collectionType: String = "scala.collection.Seq")
 
 // Exceptions that are caught and passed upstreams as errors.
 case class GeneratorException(message: String) extends Exception(message)
@@ -171,7 +171,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
   def defaultValueForDefaultInstance(field: FieldDescriptor) =
     if (field.supportsPresence) "None"
     else if (field.isMap) "scala.collection.immutable.Map.empty"
-    else if (field.isRepeated) "Nil"
+    else if (field.isRepeated) params.collectionType + ".empty"
     else defaultValueForGet(field)
 
   def javaToScalaConversion(field: FieldDescriptor) = {
@@ -196,10 +196,10 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
     val valueConversion: Expression = javaToScalaConversion(field)
 
     if (field.supportsPresence)
-      s"if ($javaHazzer) Some(${valueConversion.apply(javaGetter, isCollection = false)}) else None"
+      s"if ($javaHazzer) Some(${valueConversion.apply(javaGetter, tpe = ExpressionBuilder.Not)}) else None"
     else if (field.isRepeated)
-      valueConversion(javaGetter + ".asScala", isCollection = true)
-    else valueConversion(javaGetter, isCollection = false)
+      valueConversion(s"${javaGetter}.asScala.to[${params.collectionType}]", tpe = ExpressionBuilder.Collection)
+    else valueConversion(javaGetter, tpe = ExpressionBuilder.Not)
   }
 
   def javaFieldToScala(container: String, field: FieldDescriptor): String = {
@@ -214,7 +214,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
 
   def javaMapFieldToScala(container: String, field: FieldDescriptor) = {
     // TODO(thesamet): if both unit conversions are NoOp, we can omit the map call.
-    def unitConversion(n: String, field: FieldDescriptor) = javaToScalaConversion(field).apply(n, isCollection = false)
+    def unitConversion(n: String, field: FieldDescriptor) = javaToScalaConversion(field).apply(n, tpe = ExpressionBuilder.Not)
     s"${container}.get${field.upperScalaName}Map.asScala.map(__pv => (${unitConversion("__pv._1", field.mapType.keyField)}, ${unitConversion("__pv._2", field.mapType.valueField)})).toMap"
   }
 
@@ -240,7 +240,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
 
   def assignScalaMapToJava(scalaObject: String, javaObject: String, field: FieldDescriptor): String = {
     def valueConvert(v: String, field: FieldDescriptor) =
-      scalaToJava(field, boxPrimitives = true).apply(v, isCollection = false)
+      scalaToJava(field, boxPrimitives = true).apply(v, tpe = ExpressionBuilder.Not)
 
     val getMutableMap = s"getMutable${field.upperScalaName}" + (
       if (field.mapType.valueField.isEnum && field.getFile.isProto3) "Value" else "")
@@ -264,7 +264,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
       val scalaGetter = scalaObject + "." + fieldAccessorSymbol(field)
 
       val scalaExpr = (toBaseTypeExpr(field) andThen scalaToJava(field, boxPrimitives = field.isRepeated)).apply(
-        scalaGetter, isCollection = !field.isSingular)
+        scalaGetter, tpe = if(field.isSingular) ExpressionBuilder.Not else ExpressionBuilder.ScalaOption)
       if (field.supportsPresence || field.isInOneof)
         s"$scalaExpr.foreach($javaSetter)"
       else
@@ -284,7 +284,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         .print(message.fields) {
           case (fp, f) =>
             val e = toBaseFieldType(f)
-              .apply(fieldAccessorSymbol(f), isCollection = !f.isSingular)
+              .apply(fieldAccessorSymbol(f), tpe = if(f.isSingular) ExpressionBuilder.Not else ExpressionBuilder.ScalaOption)
             if (f.supportsPresence || f.isInOneof)
               fp.add(s"case ${f.getNumber} => $e.orNull")
             else if (f.isOptional) {
@@ -351,14 +351,14 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
   else toBaseTypeExpr(field)
 
   def toBaseType(field: FieldDescriptor)(expr: String) =
-    toBaseTypeExpr(field).apply(expr, isCollection = false)
+    toBaseTypeExpr(field).apply(expr, tpe = ExpressionBuilder.Not)
 
   def toCustomTypeExpr(field: FieldDescriptor) =
     if (field.customSingleScalaTypeName.isEmpty) Identity
     else FunctionApplication(s"${field.typeMapper}.toCustom")
 
   def toCustomType(field: FieldDescriptor)(expr: String) =
-    toCustomTypeExpr(field).apply(expr, isCollection = false)
+    toCustomTypeExpr(field).apply(expr, tpe = ExpressionBuilder.Not)
 
   def generateSerializedSizeForField(fp: FunctionalPrinter, field: FieldDescriptor): FunctionalPrinter = {
     val fieldNameSymbol = fieldAccessorSymbol(field)
@@ -510,7 +510,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         if (field.isOptional && field.supportsPresence) " = None"
         else if (field.isSingular && !field.isRequired) " = " + defaultValueForGet(field)
         else if (field.isMap) " = scala.collection.immutable.Map.empty"
-        else if (field.isRepeated) " = Nil"
+        else if (field.isRepeated) s" = ${params.collectionType}.empty"
         else ""
         s"${field.scalaName.asSymbol}: $typeName$ctorDefaultValue"
     }
@@ -534,7 +534,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         else if (field.isMap)
           printer.add(s"val __${field.scalaName} = (scala.collection.immutable.Map.newBuilder[${field.mapType.keyType}, ${field.mapType.valueType}] ++= this.${field.scalaName.asSymbol})")
         else
-          printer.add(s"val __${field.scalaName} = (scala.collection.immutable.Vector.newBuilder[${field.singleScalaTypeName}] ++= this.${field.scalaName.asSymbol})")
+          printer.add(s"val __${field.scalaName} = (${params.collectionType}.newBuilder[${field.singleScalaTypeName}] ++= this.${field.scalaName.asSymbol})")
       )
       .when(requiredFieldMap.nonEmpty) {
         fp =>
@@ -567,7 +567,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
                 fieldAccessorSymbol(field) else s"__${field.scalaName}"
               val mappedType =
                 toBaseFieldType(field).apply(expr,
-                  isCollection = !field.isSingular)
+                  tpe = if(field.isSingular) ExpressionBuilder.Not else ExpressionBuilder.ScalaOption)
               if (field.isInOneof || field.supportsPresence) (mappedType + s".getOrElse($defInstance)")
               else mappedType
             }
@@ -715,7 +715,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
               s"__fieldsMap.getOrElse(__fields.get(${field.getIndex}), $t).asInstanceOf[$baseTypeName]"
             }
 
-            val s = transform(field).apply(e, isCollection = !field.isSingular)
+            val s = transform(field).apply(e, tpe = if(field.isSingular) ExpressionBuilder.Not else ExpressionBuilder.ScalaOption)
             if (field.isMap) s + "(scala.collection.breakOut)"
             else s
         }
@@ -725,7 +725,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
               field =>
                 val typeName = if (field.isEnum) "_root_.com.google.protobuf.Descriptors.EnumValueDescriptor" else field.baseSingleScalaTypeName
                 val e = s"__fieldsMap.get(__fields.get(${field.getIndex})).asInstanceOf[scala.Option[$typeName]]"
-                (transform(field) andThen FunctionApplication(field.oneOfTypeName)).apply(e, isCollection = true)
+                (transform(field) andThen FunctionApplication(field.oneOfTypeName)).apply(e, tpe = ExpressionBuilder.ScalaOption)
             } mkString (" orElse\n")
             s"${oneOf.scalaName.asSymbol} = $elems getOrElse ${oneOf.empty}"
         }
@@ -928,7 +928,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
           }
           val default = if (defaultNeeded) s", ${defaultValueForGet(fd)}"
           else ""
-          fp.add(s"  $factoryMethod(${fd.getNumber}, _.$container)({__valueIn => ${customExpr("__valueIn", false)}}$default)")
+          fp.add(s"  $factoryMethod(${fd.getNumber}, _.$container)({__valueIn => ${customExpr("__valueIn", ExpressionBuilder.Not)}}$default)")
       }
   }
 
@@ -1016,7 +1016,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
               p.add(
                 s"""def $withMethod(__v: ${singleType}): ${message.nameSymbol} = copy(${field.getContainingOneof.scalaName.asSymbol} = ${field.oneOfTypeName}(__v))""")
           }.when(field.isRepeated) { p =>
-            val emptyValue = if (field.isMap) "scala.collection.immutable.Map.empty" else "scala.collection.Seq.empty"
+            val emptyValue = if (field.isMap) "scala.collection.immutable.Map.empty" else params.collectionType + ".empty"
             p.addStringMargin(
               s"""def $clearMethod = copy(${field.scalaName.asSymbol} = $emptyValue)
                  |def add${field.upperScalaName}(__vs: $singleType*): ${message.nameSymbol} = addAll${field.upperScalaName}(__vs)
@@ -1195,12 +1195,14 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
 }
 
 object ProtobufGenerator {
-  def parseParameters(params: String): Either[String, GeneratorParams] = {
+  val collectionTypeKey = "collection_type"
+  private def parseParameters(params: String): Either[String, GeneratorParams] = {
     params.split(",").map(_.trim).filter(_.nonEmpty).foldLeft[Either[String, GeneratorParams]](Right(GeneratorParams())) {
       case (Right(params), "java_conversions") => Right(params.copy(javaConversions = true))
       case (Right(params), "flat_package") => Right(params.copy(flatPackage = true))
       case (Right(params), "grpc") => Right(params.copy(grpc = true))
       case (Right(params), "single_line_to_string") => Right(params.copy(singleLineToString = true))
+      case (Right(params), p) if p.startsWith(collectionTypeKey) => Right(params.copy(collectionType = p.drop(collectionTypeKey.length + 1)))
       case (Right(params), p) => Left(s"Unrecognized parameter: '$p'")
       case (x, _) => x
     }

--- a/compiler-plugin/src/main/scala/scalapb/package.scala
+++ b/compiler-plugin/src/main/scala/scalapb/package.scala
@@ -1,3 +1,4 @@
+import com.trueaccord.scalapb.compiler.ProtobufGenerator
 import protocbridge.JvmGenerator
 
 package object scalapb {
@@ -5,7 +6,8 @@ package object scalapb {
     flatPackage: Boolean = false,
     javaConversions: Boolean = false,
     grpc: Boolean = true,
-    singleLineToString: Boolean = false): (JvmGenerator, Seq[String]) =
+    singleLineToString: Boolean = false,
+    collectionType: String = "scala.collection.Seq"): (JvmGenerator, Seq[String]) =
     (JvmGenerator(
       "scala",
       ScalaPbCodeGenerator),
@@ -14,5 +16,6 @@ package object scalapb {
         "java_conversions" -> javaConversions,
         "grpc" -> grpc,
         "single_line_to_string" -> singleLineToString
-      ).collect { case (name, v) if v => name })
+      ).collect { case (name, v) if v => name } :+ (ProtobufGenerator.collectionTypeKey + "=" + collectionType)
+    )
 }

--- a/e2e.sh
+++ b/e2e.sh
@@ -3,5 +3,9 @@ set -e
 sbt ++2.10.6 compilerPlugin/publishLocal runtimeJVM/publishLocal createVersionFile \
     ++2.11.8 runtimeJVM/publishLocal grpcRuntime/publishLocal
 cd e2e
-sbt clean noJava/clean noJava/test test
+for t in scala.collection.immutable.Seq scala.collection.immutable.IndexedSeq List Vector
+do
+  sbt -DcollectionType=${t} clean compile
+done
 
+sbt clean noJava/clean noJava/test test

--- a/e2e/build.sbt
+++ b/e2e/build.sbt
@@ -48,12 +48,14 @@ val commonSettings = Seq(
       exe
     })
 
+val collectionType: String = sys.props.getOrElse("collectionType", "scala.collection.Seq")
+
 lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     PB.targets in Compile := Seq(
       PB.gens.java -> (sourceManaged in Compile).value,
-      scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value
+      scalapb.gen(javaConversions = true, collectionType = collectionType) -> (sourceManaged in Compile).value
     ),
     libraryDependencies ++= Seq(
       "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.Version.scalapbVersion


### PR DESCRIPTION
https://gitter.im/trueaccord/ScalaPB?at=583dc53cb4d7ca3b7a1810fa

> Hello. Is there a way to generate List instead of Seq for repeated? I wrote a library that can convert between normal domain case classes and scalaPB generated case classes where all fields are optional. https://github.com/kailuowang/henkan#transform-between-case-classes-with-optional-field, however for repeated items, I need cats Functor and Traverse instances. There are no such instances for Seq provided out of the box.

/cc @kailuowang

Edit: also fix https://github.com/scalapb/ScalaPB/issues/208