### PR TITLE
Use JavaConverters instead of JavaConversions

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
@@ -105,7 +105,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
           p.add(
             "override " + blockingMethodSignature(m) + " = {"
           ).addIndented(
-            s"scala.collection.JavaConversions.asScalaIterator($clientCalls.blockingServerStreamingCall(channel.newCall(${m.descriptorName}, options), request))"
+            s"scala.collection.JavaConverters.asScalaIteratorConverter($clientCalls.blockingServerStreamingCall(channel.newCall(${m.descriptorName}, options), request)).asScala"
           ).add("}")
         } else {
           p.add(


### PR DESCRIPTION
JavaConversions was [deprecated since Scala 2.12.0](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/JavaConversions.scala#L59). In order to remove the deprecation warnings when compiling Scala 2.12.x projects with sources generated using ScalaPB, this PR updates the generation code to use JavaConverters instead of JavaConversions.