### PR TITLE
Better metadata for server service definitions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val grpcRuntime = project.in(file("scalapb-runtime-grpc"))
     name := "scalapb-runtime-grpc",
     libraryDependencies ++= Seq(
       "io.grpc" % "grpc-stub" % grpcVersion,
+      "io.grpc" % "grpc-protobuf" % grpcVersion,
       "org.scalatest" %% "scalatest" % "3.0.3" % "test",
       "org.mockito" % "mockito-core" % "2.8.47" % "test"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,7 @@ lazy val proptest = project.in(file("proptest"))
         "com.github.os72" % "protoc-jar" % "3.3.0.1",
         "com.google.protobuf" % "protobuf-java" % protobufVersion,
         "io.grpc" % "grpc-netty" % grpcVersion % "test",
+        "io.grpc" % "grpc-protobuf" % grpcVersion % "test",
         "com.trueaccord.lenses" %% "lenses" % "0.4.12",
         "com.trueaccord.scalapb" %% "scalapb-json4s" % "0.1.5",
         "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
@@ -66,6 +66,8 @@ trait DescriptorPimps {
     def stub = self.getName + "Stub"
 
     def methods = self.getMethods.asScala.toIndexedSeq
+
+    def descriptorName = s"SERVICE"
   }
 
   implicit class FieldDescriptorPimp(val fd: FieldDescriptor) {

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
@@ -67,7 +67,7 @@ trait DescriptorPimps {
 
     def methods = self.getMethods.asScala.toIndexedSeq
 
-    def descriptorName = s"SERVICE"
+    def descriptorName = "SERVICE"
   }
 
   implicit class FieldDescriptorPimp(val fd: FieldDescriptor) {

--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
@@ -179,23 +179,15 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
 
     val grpcServiceDescriptor = "_root_.io.grpc.ServiceDescriptor"
 
-    val schemaDescriptor: String =
-      s""".setSchemaDescriptor(new _root_.io.grpc.protobuf.ProtoFileDescriptorSupplier {
-         |  override def getFileDescriptor: _root_.com.google.protobuf.Descriptors.FileDescriptor =
-         |    ${service.getFile.fileDescriptorObjectFullName}.javaDescriptor
-         |})"""
-
-    def addMethod(method: MethodDescriptor): PrinterEndo = PrinterEndo(
-      _.add(s".addMethod(${method.descriptorName})")
-    )
-
     PrinterEndo(
       _.add(s"val ${service.descriptorName}: $grpcServiceDescriptor =")
         .indent
         .add(s"""$grpcServiceDescriptor.newBuilder("${service.getFullName}")""")
         .indent
-        .addStringMargin(schemaDescriptor)
-        .call(service.methods.map(addMethod): _*)
+        .add(s""".setSchemaDescriptor(new _root_.com.trueaccord.scalapb.grpc.ConcreteProtoFileDescriptorSupplier(${service.getFile.fileDescriptorObjectFullName}.javaDescriptor))""")
+        .print(service.methods) { case (p, method) =>
+          p.add(s".addMethod(${method.descriptorName})")
+        }
         .add(".build()")
         .outdent
         .outdent

--- a/proptest/src/test/scala/SchemaGenerators.scala
+++ b/proptest/src/test/scala/SchemaGenerators.scala
@@ -149,6 +149,7 @@ object SchemaGenerators {
       jarForClass[com.google.protobuf.Message].getPath,
       jarForClass[io.grpc.Channel].getPath,
       jarForClass[io.grpc.stub.AbstractStub[_]].getPath,
+      jarForClass[io.grpc.protobuf.ProtoFileDescriptorSupplier].getPath,
       jarForClass[com.google.common.util.concurrent.ListenableFuture[_]],
       jarForClass[javax.annotation.Nullable],
       jarForClass[com.trueaccord.lenses.Lens[_, _]].getPath,

--- a/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/ConcreteProtoFileDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/ConcreteProtoFileDescriptorSupplier.scala
@@ -1,0 +1,8 @@
+package com.trueaccord.scalapb.grpc
+
+import com.google.protobuf.Descriptors
+import io.grpc.protobuf.ProtoFileDescriptorSupplier
+
+class ConcreteProtoFileDescriptorSupplier(descriptor: Descriptors.FileDescriptor) extends ProtoFileDescriptorSupplier {
+  override def getFileDescriptor: Descriptors.FileDescriptor = descriptor
+}


### PR DESCRIPTION
Make the default wrapper create an io.grpc.ServerServiceDefinition with a proper io.grpc.ServiceDescriptor, which allows for the stock ProtoReflectionService to function properly.