### PR TITLE
Update async observer completion.

### DIFF
--- a/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
@@ -1,9 +1,8 @@
 package com.trueaccord.scalapb.grpc
 
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
-import io.grpc.{Status, StatusException}
+import io.grpc.{Status, StatusException, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
-
 import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
@@ -11,8 +10,8 @@ object Grpc {
   def guavaFuture2ScalaFuture[A](guavaFuture: ListenableFuture[A]): Future[A] = {
     val p = Promise[A]()
     Futures.addCallback(guavaFuture, new FutureCallback[A] {
-      override def onFailure(t: Throwable) = p.failure(t)
-      override def onSuccess(a: A) = p.success(a)
+      override def onFailure(t: Throwable) = p.tryFailure(t)
+      override def onSuccess(a: A) = p.trySuccess(a)
     })
     p.future
   }
@@ -22,6 +21,8 @@ object Grpc {
       observer.onNext(value)
       observer.onCompleted()
     case scala.util.Failure(s: StatusException) =>
+      observer.onError(s)
+    case scala.util.Failure(s: StatusRuntimeException) =>
       observer.onError(s)
     case scala.util.Failure(e) =>
       observer.onError(

--- a/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
@@ -10,8 +10,8 @@ object Grpc {
   def guavaFuture2ScalaFuture[A](guavaFuture: ListenableFuture[A]): Future[A] = {
     val p = Promise[A]()
     Futures.addCallback(guavaFuture, new FutureCallback[A] {
-      override def onFailure(t: Throwable) = p.tryFailure(t)
-      override def onSuccess(a: A) = p.trySuccess(a)
+      override def onFailure(t: Throwable): Unit = p.failure(t)
+      override def onSuccess(a: A): Unit = p.success(a)
     })
     p.future
   }


### PR DESCRIPTION
- Handle StatusRuntimeExceptions as well as StatusExceptions on Observer
completion.
- Use tryFailure and trySuccess for Guava -> Scala Future translation.
This avoids a spurious exception thrown on (presumedly very rare)
multiple completion of the Future.