### PR TITLE
Fix classloading error with compiler plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
The compiler plugin can potentially fail in cases where an older version of scalapb-runtime is on the classpath. Since both compilerplugin and scalapb-runtime contain copies of com.trueaccord.scalapb.Scalapb it's inderminate which one will be picked up, and thus the compiler may fail.

This is most visible in the sbt plugin. sbt, as of the 1.0.x series, includes scalapb-runtime in every build/plugin project, due to zinc-persist pulling it in transitively.

This commit changes the copy of Scalapb included in the compilerplugin jar to use a shaded version of the same class.

This fixes #325 