### PR TITLE
remove "grpcJavaVersion" from e2e Version file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,6 @@ def genVersionFile(out: File, version: String): File = {
               |object Version {
               |  val sbtPluginVersion = "$sbtPluginVersion"
               |  val scalapbVersion = "$version"
-              |  val grpcJavaVersion = "${grpcVersion}"
               |}
               |""".stripMargin.getBytes("UTF-8"))
   w.close()

--- a/e2e/build.sbt
+++ b/e2e/build.sbt
@@ -1,4 +1,4 @@
-import com.trueaccord.scalapb.Version.grpcJavaVersion
+import com.trueaccord.scalapb.compiler.Version.grpcJavaVersion
 scalaVersion in ThisBuild := "2.11.11"
 
 val grpcArtifactId = "protoc-gen-grpc-java"


### PR DESCRIPTION
We can use "com.trueaccord.scalapb.compiler.Version.grpcJavaVersion"