### PR TITLE
Override equals for generated enums. Compare values instead of objects.

### DIFF
--- a/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -20,6 +20,8 @@ trait GeneratedEnum extends Any with Product with Serializable {
 
   override def toString = name
 
+  override def equals(obj: scala.Any) = obj != null && obj.isInstanceOf[EnumType] && obj.asInstanceOf[EnumType].value == value
+
   def companion: GeneratedEnumCompanion[EnumType]
 
   def isUnrecognized: Boolean = false

--- a/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -20,7 +20,7 @@ trait GeneratedEnum extends Any with Product with Serializable {
 
   override def toString = name
 
-  override def equals(obj: scala.Any) = obj != null && obj.isInstanceOf[EnumType] && obj.asInstanceOf[EnumType].value == value
+  override def equals(obj: scala.Any) = obj != null && obj.getClass == obj.getClass && obj.asInstanceOf[GeneratedEnum].value == value
 
   def companion: GeneratedEnumCompanion[EnumType]
 


### PR DESCRIPTION
In some scenarios where GeneratedEnums are serialized/deserialized using different serialization methods - deserialised objects differ and they are not equal to generated case objects.