### PR TITLE
add equals to GeneratedEnum

### DIFF
--- a/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -25,6 +25,8 @@ trait GeneratedEnum extends Any with Product with Serializable {
     case _ => false
   }
 
+  override def hashCode = value
+
   def companion: GeneratedEnumCompanion[EnumType]
 
   def isUnrecognized: Boolean = false

--- a/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -20,6 +20,11 @@ trait GeneratedEnum extends Any with Product with Serializable {
 
   override def toString = name
 
+  override def equals(obj: scala.Any) = obj match {
+    case enumObj: GeneratedEnum => (enumObj canEqual this) && this.value == enumObj.value
+    case _ => false
+  }
+
   def companion: GeneratedEnumCompanion[EnumType]
 
   def isUnrecognized: Boolean = false


### PR DESCRIPTION
Define equals method for GeneratedEnum. Previously case objects defaulted to object reference comparison, which do not work in some cases, f.e. when comparing case object with object deserialized using other serialization methods than Protobuf.