### PR TITLE
fix name collision between oneof and ValueType

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
@@ -251,9 +251,21 @@ trait DescriptorPimps {
   }
 
   implicit class OneofDescriptorPimp(val oneof: OneofDescriptor) {
+
+    def javaEnumName = {
+      val name = NameUtils.snakeCaseToCamelCase(oneof.getName, true)
+      s"get${name}Case"
+    }
+
     def scalaName = NameUtils.snakeCaseToCamelCase(oneof.getName)
 
-    def upperScalaName = NameUtils.snakeCaseToCamelCase(oneof.getName, true)
+    def upperScalaName = {
+      val name = oneof.getName match {
+        case "ValueType" | "value_type" => "ValueTypeOneof"
+        case n => n
+      }
+      NameUtils.snakeCaseToCamelCase(name, true)
+    }
 
     def fields: IndexedSeq[FieldDescriptor] = (0 until oneof.getFieldCount).map(oneof.getField).filter(_.getLiteType != FieldType.GROUP)
 

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -764,8 +764,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         }
         val oneOfs = message.getOneofs.asScala.map {
           case oneOf =>
-            val javaEnumName = s"get${oneOf.upperScalaName}Case"
-            val head = s"${oneOf.scalaName.asSymbol} = javaPbSource.$javaEnumName.getNumber match {"
+            val head = s"${oneOf.scalaName.asSymbol} = javaPbSource.${oneOf.javaEnumName}.getNumber match {"
             val body = oneOf.fields.map {
               field =>
                 s"  case ${field.getNumber} => ${field.oneOfTypeName}(${javaFieldToScala("javaPbSource", field)})"

--- a/e2e/src/main/protobuf/names.dot.proto
+++ b/e2e/src/main/protobuf/names.dot.proto
@@ -86,6 +86,20 @@ message Issue348 {
   optional ValueType value_type = 1;
 }
 
+message ValueTypeOneOf {
+  oneof ValueType {
+    string value_1 = 1;
+    int32  value_2 = 2;
+  }
+}
+
+message ValueTypeOneOfUnderscore {
+  oneof value_type {
+    string value_1 = 1;
+    int32  value_2 = 2;
+  }
+}
+
 // https://github.com/scalapb/ScalaPB/issues/395
 message String {
   optional string value = 1;


### PR DESCRIPTION
This fixes a naming collision between `GeneratedEnumCompanion` and the generated code when `ValueType` or `value_type` is used as the oneof name.