### PR TITLE
Add `then` as reserved word for scala

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
@@ -18,7 +18,7 @@ trait DescriptorPimps {
     "finally", "for", "forSome", "if", "implicit",
     "import", "lazy", "macro", "match", "new", "null",
     "object", "override", "package", "private", "protected",
-    "return", "sealed", "super", "this", "throw",
+    "return", "sealed", "super", "then", "this", "throw",
     "trait", "try", "true", "type", "val",
     "var", "while", "with", "yield",
     "ne", "scala")


### PR DESCRIPTION
This solves errors like the following:
```
[error] <FILE>: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
```