### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   - scala: 2.11.12
     env: SCALA_NATIVE
     before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/9069e8d447f7a9/bin/travis_setup.sh | bash -x
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
     script:
     - sbt runtimeNative/test "show runtimeNative/nativeMissingDependencies"
 


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.