### PR TITLE
Fix 427 and optionally tolerate forbidden field names

### DIFF
--- a/compiler-plugin/src/main/java/scalapb/options/compiler/Scalapb.java
+++ b/compiler-plugin/src/main/java/scalapb/options/compiler/Scalapb.java
@@ -290,7 +290,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.ScalaPbOptions)
       ScalaPbOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use ScalaPbOptions.newBuilder() to construct.
     private ScalaPbOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -318,9 +317,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -333,8 +329,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -902,6 +898,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -1239,7 +1236,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -1252,12 +1249,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2194,7 +2191,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ScalaPbOptions(input, extensionRegistry);
+          return new ScalaPbOptions(input, extensionRegistry);
       }
     };
 
@@ -2393,7 +2390,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.MessageOptions)
       MessageOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use MessageOptions.newBuilder() to construct.
     private MessageOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -2416,9 +2412,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2431,8 +2424,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -2828,6 +2821,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -3080,7 +3074,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -3093,12 +3087,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3836,7 +3830,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MessageOptions(input, extensionRegistry);
+          return new MessageOptions(input, extensionRegistry);
       }
     };
 
@@ -4021,7 +4015,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.FieldOptions)
       FieldOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use FieldOptions.newBuilder() to construct.
     private FieldOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -4046,9 +4039,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4061,8 +4051,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -4523,6 +4513,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -4812,7 +4803,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -4825,12 +4816,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5562,7 +5553,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FieldOptions(input, extensionRegistry);
+          return new FieldOptions(input, extensionRegistry);
       }
     };
 
@@ -5691,7 +5682,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.EnumOptions)
       EnumOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use EnumOptions.newBuilder() to construct.
     private EnumOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -5712,9 +5702,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5727,8 +5714,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -5988,6 +5975,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -6214,7 +6202,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -6227,12 +6215,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6692,7 +6680,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EnumOptions(input, extensionRegistry);
+          return new EnumOptions(input, extensionRegistry);
       }
     };
 
@@ -6757,7 +6745,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.EnumValueOptions)
       EnumValueOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use EnumValueOptions.newBuilder() to construct.
     private EnumValueOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -6776,9 +6763,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6791,8 +6775,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -6914,6 +6898,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -7110,7 +7095,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -7123,12 +7108,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7338,7 +7323,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EnumValueOptions(input, extensionRegistry);
+          return new EnumValueOptions(input, extensionRegistry);
       }
     };
 
@@ -7403,7 +7388,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.OneofOptions)
       OneofOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use OneofOptions.newBuilder() to construct.
     private OneofOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -7422,9 +7406,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7437,8 +7418,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -7560,6 +7541,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -7756,7 +7738,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -7769,12 +7751,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7984,7 +7966,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneofOptions(input, extensionRegistry);
+          return new OneofOptions(input, extensionRegistry);
       }
     };
 
@@ -8148,7 +8130,7 @@ public final class Scalapb {
       "ollection_type\030\010 \001(\t\022\037\n\027preserve_unknown" +
       "_fields\030\t \001(\010\022\'\n\035test_only_no_java_conve" +
       "rsions\030\241\215\006 \001(\010\"~\n\016MessageOptions\022\017\n\007exte" +
-      "nds\030\001 \003(\t\022\031\n\021companion_extends\030\002 \003(\t\022\023\n\013" +
+      "nds\030\001 \003(\t\022\031\n\021companion_extends\030\002 \003(\t\022\023\n\013",
       "annotations\030\003 \003(\t\022\014\n\004type\030\004 \001(\t\022\035\n\025compa" +
       "nion_annotations\030\005 \003(\t\"\224\001\n\014FieldOptions\022" +
       "\014\n\004type\030\001 \001(\t\022\022\n\nscala_name\030\002 \001(\t\022\027\n\017col" +
@@ -8158,7 +8140,7 @@ public final class Scalapb {
       "\001 \003(\t\022\031\n\021companion_extends\030\002 \003(\t\022\014\n\004type" +
       "\030\003 \001(\t\"#\n\020EnumValueOptions\022\017\n\007extends\030\001 " +
       "\003(\t\"\037\n\014OneofOptions\022\017\n\007extends\030\001 \003(\t:G\n\007" +
-      "options\022\034.google.protobuf.FileOptions\030\374\007" +
+      "options\022\034.google.protobuf.FileOptions\030\374\007",
       " \001(\0132\027.scalapb.ScalaPbOptions:J\n\007message" +
       "\022\037.google.protobuf.MessageOptions\030\374\007 \001(\013" +
       "2\027.scalapb.MessageOptions:D\n\005field\022\035.goo" +
@@ -8168,7 +8150,7 @@ public final class Scalapb {
       "numOptions:Q\n\nenum_value\022!.google.protob" +
       "uf.EnumValueOptions\030\374\007 \001(\0132\031.scalapb.Enu" +
       "mValueOptions:D\n\005oneof\022\035.google.protobuf" +
-      ".OneofOptions\030\374\007 \001(\0132\025.scalapb.OneofOpti" +
+      ".OneofOptions\030\374\007 \001(\0132\025.scalapb.OneofOpti",
       "onsB9\n\030scalapb.options.compiler\342?\034\n\030scal" +
       "apb.options.compiler\020\001"
     };

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
@@ -79,8 +79,9 @@ trait DescriptorPimps {
     else fd.getName match {
       case ("number" | "value") if fd.isInOneof => "_" + fd.getName
       case "serialized_size" => "_serializedSize"
-      case "class" => "_class"
-      case x => NameUtils.snakeCaseToCamelCase(x)
+      case x =>
+        val candidate = NameUtils.snakeCaseToCamelCase(x)
+        if (ProtoValidation.ForbiddenFieldNames.contains(candidate)) "_" + candidate else candidate
     }
 
     def upperScalaName: String = if (fieldOptions.getScalaName.nonEmpty)

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
@@ -80,8 +80,7 @@ trait DescriptorPimps {
       case ("number" | "value") if fd.isInOneof => "_" + fd.getName
       case "serialized_size" => "_serializedSize"
       case x =>
-        val candidate = NameUtils.snakeCaseToCamelCase(x)
-        if (ProtoValidation.ForbiddenFieldNames.contains(candidate)) "_" + candidate else candidate
+        getNameWithFallback(x, false, true)
     }
 
     def upperScalaName: String = if (fieldOptions.getScalaName.nonEmpty)
@@ -89,13 +88,21 @@ trait DescriptorPimps {
     else fd.getName match {
       case "serialized_size" => "_SerializedSize"
       case "class" => "_Class"
-      case x => NameUtils.snakeCaseToCamelCase(x, true)
+      case x => getNameWithFallback(x, true, true)
+    }
+
+    private def getNameWithFallback(x: String, upperInitial: Boolean, prefix: Boolean) = {
+      val candidate = NameUtils.snakeCaseToCamelCase(x, upperInitial)
+      if (ProtoValidation.ForbiddenFieldNames.contains(candidate)) {
+        if (prefix) "_" + candidate
+        else candidate + "_"
+      } else candidate
     }
 
     def upperJavaName: String = fd.getName match {
       case "serialized_size" => "SerializedSize_"
       case "class" => "Class_"
-      case x => NameUtils.snakeCaseToCamelCase(x, true)
+      case x => getNameWithFallback(x, true, false)
     }
 
     def fieldNumberConstantName: String = fd.getName.toUpperCase() + "_FIELD_NUMBER"

--- a/compiler-plugin/src/main/scala/scalapb/compiler/NameUtils.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/NameUtils.scala
@@ -41,5 +41,16 @@ object NameUtils {
     b.toString
   }
 
+  private[compiler] sealed abstract class Case extends Product with Serializable { def isPascal: Boolean }
+  private[compiler] object Case {
+    private[compiler] case object CamelCase extends Case { def isPascal = false }
+    private[compiler] case object PascalCase extends Case { def isPascal = true }
+  }
+
+  private[compiler] sealed abstract class Appendage extends Product with Serializable { def isPrefix: Boolean }
+  private[compiler] object Appendage {
+    private[compiler] case object Prefix extends Appendage { def isPrefix = true }
+    private[compiler] case object Postfix extends Appendage { def isPrefix = false }
+  }
 
 }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtoValidation.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtoValidation.scala
@@ -4,9 +4,6 @@ import com.google.protobuf.Descriptors._
 import scala.collection.JavaConverters._
 
 class ProtoValidation(val params: GeneratorParams) extends DescriptorPimps {
-  val ForbiddenFieldNames = Set(
-    "hashCode", "equals", "clone", "copy", "finalize", "getClass", "notify", "notifyAll", "toString", "wait",
-    "productArity", "productIterator", "productPrefix")
 
   def validateFile(fd: FileDescriptor): Unit = {
     fd.getEnumTypes.asScala.foreach(validateEnum)
@@ -32,7 +29,7 @@ class ProtoValidation(val params: GeneratorParams) extends DescriptorPimps {
   }
 
   def validateField(fd: FieldDescriptor): Unit = {
-    if (ForbiddenFieldNames.contains(fd.scalaName))
+    if (ProtoValidation.ForbiddenFieldNames.contains(fd.scalaName))
       throw new GeneratorException(
         s"Field named '${fd.getName}' in message '${fd.getFullName}' is not allowed. See https://scalapb.github.io/customizations.html#custom-names")
     if (!fd.isRepeated && fd.fieldOptions.hasCollectionType)
@@ -52,4 +49,24 @@ class ProtoValidation(val params: GeneratorParams) extends DescriptorPimps {
       throw new GeneratorException(
         s"${fd.getFullName}: Field ${fd.getName} has no_box set but is not an optional field.")
   }
+}
+
+object ProtoValidation {
+
+  val ForbiddenFieldNames = Set(
+    "hashCode",
+    "equals",
+    "class",
+    "clone",
+    "copy",
+    "finalize",
+    "getClass",
+    "notify",
+    "notifyAll",
+    "toString",
+    "wait",
+    "productArity",
+    "productIterator",
+    "productPrefix"
+  )
 }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -541,7 +541,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
     else s"(${funcs(0)} _)" + funcs.tail.map(func => s".compose($func)").mkString
 
   def generateWriteTo(message: Descriptor)(fp: FunctionalPrinter) =
-    fp.add(s"def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {")
+    fp.add(s"def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {")
       .indent
       .print(message.fields.sortBy(_.getNumber).zipWithIndex) {
         case (printer, (field, index)) =>

--- a/e2e/src/main/protobuf/names.dot.proto
+++ b/e2e/src/main/protobuf/names.dot.proto
@@ -9,6 +9,12 @@ message Match {
   optional int32 for = 2;
 }
 
+message IfThenElse {
+  optional int32 if = 1;
+  optional int32 then = 2;
+  optional int32 else = 3;
+}
+
 message Option {
 }
 
@@ -47,6 +53,10 @@ message WeirdNamesRequired {
 }
 
 message yield {
+}
+
+// https://github.com/scalapb/ScalaPB/issues/427
+message Unit {
 }
 
 message Any {

--- a/scalapb-runtime/jvm/src/main/java/scalapb/options/Scalapb.java
+++ b/scalapb-runtime/jvm/src/main/java/scalapb/options/Scalapb.java
@@ -290,7 +290,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.ScalaPbOptions)
       ScalaPbOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use ScalaPbOptions.newBuilder() to construct.
     private ScalaPbOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -318,9 +317,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -333,8 +329,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -902,6 +898,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -1239,7 +1236,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -1252,12 +1249,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2194,7 +2191,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ScalaPbOptions(input, extensionRegistry);
+          return new ScalaPbOptions(input, extensionRegistry);
       }
     };
 
@@ -2393,7 +2390,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.MessageOptions)
       MessageOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use MessageOptions.newBuilder() to construct.
     private MessageOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -2416,9 +2412,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2431,8 +2424,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -2828,6 +2821,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -3080,7 +3074,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -3093,12 +3087,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3836,7 +3830,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MessageOptions(input, extensionRegistry);
+          return new MessageOptions(input, extensionRegistry);
       }
     };
 
@@ -4021,7 +4015,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.FieldOptions)
       FieldOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use FieldOptions.newBuilder() to construct.
     private FieldOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -4046,9 +4039,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4061,8 +4051,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -4523,6 +4513,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -4812,7 +4803,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -4825,12 +4816,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5562,7 +5553,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FieldOptions(input, extensionRegistry);
+          return new FieldOptions(input, extensionRegistry);
       }
     };
 
@@ -5691,7 +5682,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.EnumOptions)
       EnumOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use EnumOptions.newBuilder() to construct.
     private EnumOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -5712,9 +5702,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5727,8 +5714,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -5988,6 +5975,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -6214,7 +6202,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -6227,12 +6215,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6692,7 +6680,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EnumOptions(input, extensionRegistry);
+          return new EnumOptions(input, extensionRegistry);
       }
     };
 
@@ -6757,7 +6745,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.EnumValueOptions)
       EnumValueOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use EnumValueOptions.newBuilder() to construct.
     private EnumValueOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -6776,9 +6763,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6791,8 +6775,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -6914,6 +6898,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -7110,7 +7095,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -7123,12 +7108,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7338,7 +7323,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EnumValueOptions(input, extensionRegistry);
+          return new EnumValueOptions(input, extensionRegistry);
       }
     };
 
@@ -7403,7 +7388,6 @@ public final class Scalapb {
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:scalapb.OneofOptions)
       OneofOptionsOrBuilder {
-  private static final long serialVersionUID = 0L;
     // Use OneofOptions.newBuilder() to construct.
     private OneofOptions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -7422,9 +7406,6 @@ public final class Scalapb {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7437,8 +7418,8 @@ public final class Scalapb {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -7560,6 +7541,7 @@ public final class Scalapb {
       return size;
     }
 
+    private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
@@ -7756,7 +7738,7 @@ public final class Scalapb {
       }
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.setField(field, value);
       }
       public Builder clearField(
@@ -7769,12 +7751,12 @@ public final class Scalapb {
       }
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index, Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7984,7 +7966,7 @@ public final class Scalapb {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneofOptions(input, extensionRegistry);
+          return new OneofOptions(input, extensionRegistry);
       }
     };
 
@@ -8148,7 +8130,7 @@ public final class Scalapb {
       "\001(\010\022\027\n\017collection_type\030\010 \001(\t\022\037\n\027preserve" +
       "_unknown_fields\030\t \001(\010\022\'\n\035test_only_no_ja" +
       "va_conversions\030\241\215\006 \001(\010\"~\n\016MessageOptions" +
-      "\022\017\n\007extends\030\001 \003(\t\022\031\n\021companion_extends\030\002" +
+      "\022\017\n\007extends\030\001 \003(\t\022\031\n\021companion_extends\030\002",
       " \003(\t\022\023\n\013annotations\030\003 \003(\t\022\014\n\004type\030\004 \001(\t\022" +
       "\035\n\025companion_annotations\030\005 \003(\t\"\224\001\n\014Field" +
       "Options\022\014\n\004type\030\001 \001(\t\022\022\n\nscala_name\030\002 \001(" +
@@ -8158,7 +8140,7 @@ public final class Scalapb {
       "extends\030\001 \003(\t\022\031\n\021companion_extends\030\002 \003(\t" +
       "\022\014\n\004type\030\003 \001(\t\"#\n\020EnumValueOptions\022\017\n\007ex" +
       "tends\030\001 \003(\t\"\037\n\014OneofOptions\022\017\n\007extends\030\001" +
-      " \003(\t:G\n\007options\022\034.google.protobuf.FileOp" +
+      " \003(\t:G\n\007options\022\034.google.protobuf.FileOp",
       "tions\030\374\007 \001(\0132\027.scalapb.ScalaPbOptions:J\n" +
       "\007message\022\037.google.protobuf.MessageOption" +
       "s\030\374\007 \001(\0132\027.scalapb.MessageOptions:D\n\005fie" +
@@ -8168,7 +8150,7 @@ public final class Scalapb {
       "calapb.EnumOptions:Q\n\nenum_value\022!.googl" +
       "e.protobuf.EnumValueOptions\030\374\007 \001(\0132\031.sca" +
       "lapb.EnumValueOptions:D\n\005oneof\022\035.google." +
-      "protobuf.OneofOptions\030\374\007 \001(\0132\025.scalapb.O" +
+      "protobuf.OneofOptions\030\374\007 \001(\0132\025.scalapb.O",
       "neofOptionsB\'\n\017scalapb.options\342?\023\n\017scala" +
       "pb.options\020\001"
     };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/any/Any.scala
@@ -121,7 +121,7 @@ final case class Any(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = typeUrl
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
@@ -75,7 +75,7 @@ final case class Api(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
@@ -54,7 +54,7 @@ final case class Method(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
@@ -110,7 +110,7 @@ final case class Mixin(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -57,7 +57,7 @@ final case class CodeGeneratorRequest(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       fileToGenerate.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -39,7 +39,7 @@ final case class CodeGeneratorResponse(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       error.foreach { __v =>
         _output__.writeString(1, __v)
       };
@@ -215,7 +215,7 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         name.foreach { __v =>
           _output__.writeString(1, __v)
         };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
@@ -36,7 +36,7 @@ final case class Version(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       major.foreach { __v =>
         _output__.writeInt32(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -49,7 +49,7 @@ final case class DescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };
@@ -325,7 +325,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         start.foreach { __v =>
           _output__.writeInt32(1, __v)
         };
@@ -452,7 +452,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         start.foreach { __v =>
           _output__.writeInt32(1, __v)
         };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -31,7 +31,7 @@ final case class EnumDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
@@ -42,7 +42,7 @@ final case class EnumOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       allowAlias.foreach { __v =>
         _output__.writeBool(2, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -30,7 +30,7 @@ final case class EnumValueDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -37,7 +37,7 @@ final case class EnumValueOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -71,7 +71,7 @@ final case class FieldDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -99,7 +99,7 @@ final case class FieldOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       ctype.foreach { __v =>
         _output__.writeEnum(1, __v.value)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -71,7 +71,7 @@ final case class FileDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -28,7 +28,7 @@ final case class FileDescriptorSet(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       file.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -127,7 +127,7 @@ final case class FileOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       javaPackage.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -33,7 +33,7 @@ final case class GeneratedCodeInfo(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       annotation.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -165,7 +165,7 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         if (path.nonEmpty) {
           _output__.writeTag(1, 2)
           _output__.writeUInt32NoTag(pathSerializedSize)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
@@ -88,7 +88,7 @@ final case class MessageOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       messageSetWireFormat.foreach { __v =>
         _output__.writeBool(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -44,7 +44,7 @@ final case class MethodDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -39,7 +39,7 @@ final case class MethodOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(33, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -28,7 +28,7 @@ final case class OneofDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
@@ -30,7 +30,7 @@ final case class OneofOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       uninterpretedOption.foreach { __v =>
         _output__.writeTag(999, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -31,7 +31,7 @@ final case class ServiceDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -37,7 +37,7 @@ final case class ServiceOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(33, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -73,7 +73,7 @@ final case class SourceCodeInfo(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       location.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -285,7 +285,7 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         if (path.nonEmpty) {
           _output__.writeTag(1, 2)
           _output__.writeUInt32NoTag(pathSerializedSize)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -48,7 +48,7 @@ final case class UninterpretedOption(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeTag(2, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -253,7 +253,7 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         _output__.writeString(1, namePart)
         _output__.writeBool(2, isExtension)
       }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
@@ -97,7 +97,7 @@ final case class Duration(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = seconds
         if (__v != 0L) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
@@ -19,7 +19,7 @@ package com.google.protobuf.empty
 final case class Empty(
     ) extends scalapb.GeneratedMessage with scalapb.Message[Empty] with scalapb.lenses.Updatable[Empty] {
     final override def serializedSize: _root_.scala.Int = 0
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
     }
     def mergeFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): com.google.protobuf.empty.Empty = {
       var _done__ = false

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
@@ -230,7 +230,7 @@ final case class FieldMask(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       paths.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
@@ -31,7 +31,7 @@ final case class SourceContext(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = fileName
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
@@ -32,7 +32,7 @@ final case class ListValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       values.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
@@ -37,7 +37,7 @@ final case class Struct(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       fields.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(com.google.protobuf.struct.Struct._typemapper_fields.toBase(__v).serializedSize)
@@ -146,7 +146,7 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         {
           val __v = key
           if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
@@ -36,7 +36,7 @@ final case class Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       kind.nullValue.foreach { __v =>
         _output__.writeEnum(1, __v.value)
       };

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
@@ -113,7 +113,7 @@ final case class Timestamp(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = seconds
         if (__v != 0L) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
@@ -46,7 +46,7 @@ final case class Enum(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
@@ -38,7 +38,7 @@ final case class EnumValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -68,7 +68,7 @@ final case class Field(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = kind
         if (__v != com.google.protobuf.`type`.Field.Kind.TYPE_UNKNOWN) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
@@ -40,7 +40,7 @@ final case class OptionProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
@@ -50,7 +50,7 @@ final case class Type(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
@@ -31,7 +31,7 @@ final case class BoolValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != false) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
@@ -31,7 +31,7 @@ final case class BytesValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != _root_.com.google.protobuf.ByteString.EMPTY) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
@@ -31,7 +31,7 @@ final case class DoubleValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0.0) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
@@ -31,7 +31,7 @@ final case class FloatValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0.0f) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
@@ -31,7 +31,7 @@ final case class Int32Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
@@ -31,7 +31,7 @@ final case class Int64Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0L) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
@@ -31,7 +31,7 @@ final case class StringValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != "") {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
@@ -31,7 +31,7 @@ final case class UInt32Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0) {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
@@ -31,7 +31,7 @@ final case class UInt64Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0L) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/any/Any.scala
@@ -121,7 +121,7 @@ final case class Any(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = typeUrl
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Api.scala
@@ -74,7 +74,7 @@ final case class Api(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Method.scala
@@ -53,7 +53,7 @@ final case class Method(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
@@ -110,7 +110,7 @@ final case class Mixin(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -56,7 +56,7 @@ final case class CodeGeneratorRequest(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       fileToGenerate.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -38,7 +38,7 @@ final case class CodeGeneratorResponse(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       error.foreach { __v =>
         _output__.writeString(1, __v)
       };
@@ -204,7 +204,7 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         name.foreach { __v =>
           _output__.writeString(1, __v)
         };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
@@ -36,7 +36,7 @@ final case class Version(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       major.foreach { __v =>
         _output__.writeInt32(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -48,7 +48,7 @@ final case class DescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };
@@ -298,7 +298,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         start.foreach { __v =>
           _output__.writeInt32(1, __v)
         };
@@ -415,7 +415,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         start.foreach { __v =>
           _output__.writeInt32(1, __v)
         };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -30,7 +30,7 @@ final case class EnumDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
@@ -41,7 +41,7 @@ final case class EnumOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       allowAlias.foreach { __v =>
         _output__.writeBool(2, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -30,7 +30,7 @@ final case class EnumValueDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -36,7 +36,7 @@ final case class EnumValueOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -71,7 +71,7 @@ final case class FieldDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -98,7 +98,7 @@ final case class FieldOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       ctype.foreach { __v =>
         _output__.writeEnum(1, __v.value)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -70,7 +70,7 @@ final case class FileDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -27,7 +27,7 @@ final case class FileDescriptorSet(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       file.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -126,7 +126,7 @@ final case class FileOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       javaPackage.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -32,7 +32,7 @@ final case class GeneratedCodeInfo(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       annotation.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -156,7 +156,7 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         if (path.nonEmpty) {
           _output__.writeTag(1, 2)
           _output__.writeUInt32NoTag(pathSerializedSize)

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
@@ -87,7 +87,7 @@ final case class MessageOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       messageSetWireFormat.foreach { __v =>
         _output__.writeBool(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -44,7 +44,7 @@ final case class MethodDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -38,7 +38,7 @@ final case class MethodOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(33, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -28,7 +28,7 @@ final case class OneofDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
@@ -29,7 +29,7 @@ final case class OneofOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       uninterpretedOption.foreach { __v =>
         _output__.writeTag(999, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -30,7 +30,7 @@ final case class ServiceDescriptorProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -36,7 +36,7 @@ final case class ServiceOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       deprecated.foreach { __v =>
         _output__.writeBool(33, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -72,7 +72,7 @@ final case class SourceCodeInfo(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       location.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -276,7 +276,7 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         if (path.nonEmpty) {
           _output__.writeTag(1, 2)
           _output__.writeUInt32NoTag(pathSerializedSize)

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -47,7 +47,7 @@ final case class UninterpretedOption(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       name.foreach { __v =>
         _output__.writeTag(2, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)
@@ -232,7 +232,7 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         _output__.writeString(1, namePart)
         _output__.writeBool(2, isExtension)
       }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
@@ -97,7 +97,7 @@ final case class Duration(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = seconds
         if (__v != 0L) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
@@ -19,7 +19,7 @@ package com.google.protobuf.empty
 final case class Empty(
     ) extends scalapb.GeneratedMessage with scalapb.Message[Empty] with scalapb.lenses.Updatable[Empty] {
     final override def serializedSize: _root_.scala.Int = 0
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
     }
     def mergeFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): com.google.protobuf.empty.Empty = {
       var _done__ = false

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
@@ -229,7 +229,7 @@ final case class FieldMask(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       paths.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
@@ -31,7 +31,7 @@ final case class SourceContext(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = fileName
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
@@ -31,7 +31,7 @@ final case class ListValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       values.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(__v.serializedSize)

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
@@ -36,7 +36,7 @@ final case class Struct(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       fields.foreach { __v =>
         _output__.writeTag(1, 2)
         _output__.writeUInt32NoTag(com.google.protobuf.struct.Struct._typemapper_fields.toBase(__v).serializedSize)
@@ -131,7 +131,7 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
         }
         read
       }
-      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+      def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
         {
           val __v = key
           if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Value.scala
@@ -36,7 +36,7 @@ final case class Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       kind.nullValue.foreach { __v =>
         _output__.writeEnum(1, __v.value)
       };

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
@@ -113,7 +113,7 @@ final case class Timestamp(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = seconds
         if (__v != 0L) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Enum.scala
@@ -45,7 +45,7 @@ final case class Enum(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
@@ -37,7 +37,7 @@ final case class EnumValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -67,7 +67,7 @@ final case class Field(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = kind
         if (__v != com.google.protobuf.`type`.Field.Kind.TYPE_UNKNOWN) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
@@ -40,7 +40,7 @@ final case class OptionProto(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Type.scala
@@ -49,7 +49,7 @@ final case class Type(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = name
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
@@ -31,7 +31,7 @@ final case class BoolValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != false) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
@@ -31,7 +31,7 @@ final case class BytesValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != _root_.com.google.protobuf.ByteString.EMPTY) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
@@ -31,7 +31,7 @@ final case class DoubleValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0.0) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
@@ -31,7 +31,7 @@ final case class FloatValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0.0f) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
@@ -31,7 +31,7 @@ final case class Int32Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
@@ -31,7 +31,7 @@ final case class Int64Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0L) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
@@ -31,7 +31,7 @@ final case class StringValue(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != "") {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
@@ -31,7 +31,7 @@ final case class UInt32Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0) {

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
@@ -31,7 +31,7 @@ final case class UInt64Value(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       {
         val __v = value
         if (__v != 0L) {

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumOptions.scala
@@ -36,7 +36,7 @@ final case class EnumOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       `extends`.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumValueOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumValueOptions.scala
@@ -27,7 +27,7 @@ final case class EnumValueOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       `extends`.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/FieldOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/FieldOptions.scala
@@ -48,7 +48,7 @@ final case class FieldOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       `type`.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/MessageOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/MessageOptions.scala
@@ -44,7 +44,7 @@ final case class MessageOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       `extends`.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/OneofOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/OneofOptions.scala
@@ -27,7 +27,7 @@ final case class OneofOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       `extends`.foreach { __v =>
         _output__.writeString(1, __v)
       };

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
@@ -78,7 +78,7 @@ final case class ScalaPbOptions(
       }
       read
     }
-    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): Unit = {
+    def writeTo(`_output__`: _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
       packageName.foreach { __v =>
         _output__.writeString(1, __v)
       };


### PR DESCRIPTION
scalaPB's current solution to forbidden field names assumes that the developer has control of all .proto sources, but that may not be the case. This PR
- Handles Unit message names
- pre/postFixes forbidden field names with an underscore according to the language.

Please review.