### PR TITLE
Add `setSampledToLocalTracing(true)` to service method descriptor.

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -170,6 +170,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
           |  $grpcMethodDescriptor.newBuilder()
           |    .setType($grpcMethodDescriptor.MethodType.$methodType)
           |    .setFullMethodName($grpcMethodDescriptor.generateFullMethodName("${service.getFullName}", "${method.getName}"))
+          |    .setSampledToLocalTracing(true)
           |    .setRequestMarshaller(${marshaller(method.scalaIn)})
           |    .setResponseMarshaller(${marshaller(method.scalaOut)})
           |    .build()


### PR DESCRIPTION
This enables saving of RPC samples locally in opencensus tracing infrastructure. Same method is used by Java gRPC generator.

Fixes scalapb/ScalaPB#425