### PR TITLE
Remove scala from keyword list.

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorPimps.scala
@@ -21,7 +21,7 @@ trait DescriptorPimps {
     "return", "sealed", "super", "then", "this", "throw",
     "trait", "try", "true", "type", "val",
     "var", "while", "with", "yield",
-    "ne", "scala")
+    "ne")
 
   implicit class AsSymbolPimp(val s: String) {
     def asSymbol: String = if (SCALA_RESERVED_WORDS.contains(s)) s"`$s`" else s


### PR DESCRIPTION
The name "scala" is not a reserved Scala keyword.
Currently generated code in a package with "scala" contains backticks.

```scala
// before
package `scala`.meta
// after
package scala.meta
```

Context: https://github.com/scalameta/scalameta/pull/1533#discussion_r188666827