### PR TITLE
update protobuf version to 3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val Scala211 = "2.11.12"
 
 val Scala212 = "2.12.6"
 
-val protobufVersion = "3.5.1"
+val protobufVersion = "3.6.0"
 
 val scalacheckVersion = "1.14.0"
 

--- a/scalapbc/build.sbt
+++ b/scalapbc/build.sbt
@@ -1,5 +1,5 @@
 enablePlugins(JavaAppPackaging)
 
 libraryDependencies ++= Seq(
-  "com.github.os72" % "protoc-jar" % "3.5.1.1"
+  "com.github.os72" % "protoc-jar" % "3.6.0"
 )


### PR DESCRIPTION
I had a problem generating code from google's apis at github.com/googleapis/googleapis due to the use of `php_metadata_namespace`.  Turns out this was added in protobuf 3.6.

This update fixed that issue.