### PR TITLE
remove deprecated usage of addCallback

### DIFF
--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Grpc.scala
@@ -1,6 +1,6 @@
 package scalapb.grpc
 
-import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture, MoreExecutors}
 import io.grpc.{Status, StatusException, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
 import scala.concurrent.{Future, Promise}
@@ -12,7 +12,7 @@ object Grpc {
     Futures.addCallback(guavaFuture, new FutureCallback[A] {
       override def onFailure(t: Throwable): Unit = p.failure(t)
       override def onSuccess(a: A): Unit         = p.success(a)
-    })
+    }, MoreExecutors.directExecutor())
     p.future
   }
 


### PR DESCRIPTION
Hi @thesamet,
we were trying to upgrade to guava 26.0 and then we found out that the flavour with no executor was deprecated and then removed on July 2018.
it's just a suggestion, feel free to edit/remove/solve it in any other way.
Thanks!
@simuons @vipo