### PR TITLE
implement proto2 sealed trait without Empty as default value, use Option for optional sealed trait fields

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -331,7 +331,7 @@ class ProtobufGenerator(
            else
              ".set") + field.upperJavaName + (if (field.isEnum && field.getFile.isProto3) "Value"
                                               else "")
-        val scalaGetter = 
+        val scalaGetter =
           if (field.isSealedOneofType && field.isOptional && !field.isInOneof && field.getFile.isProto2 && !message.isMapEntry) {
             scalaObject + "." + fieldAccessorSymbol(field) + ".orNull"
           } else {
@@ -364,27 +364,29 @@ class ProtobufGenerator(
               fp.add(s"case ${f.getNumber} => $e.orNull")
             else if (f.isOptional) {
               if (f.isSealedOneofType && f.isOptional && f.getFile.isProto2 && !message.isMapEntry) {
-                    val fName = fieldAccessorSymbol(f)
+                val fName = fieldAccessorSymbol(f)
                 fp.add(s"case ${f.getNumber} => {")
                   .indent
-                  .add(s"${fName}.map(local_0 => ${toBaseFieldType(f).apply("local_0", enclosingType = f.enclosingType)} )")
+                  .add(
+                    s"${fName}.map(local_0 => ${toBaseFieldType(f).apply("local_0", enclosingType = f.enclosingType)} )"
+                  )
                   .outdent
                   .add("}")
               } else {
                 // In proto3, drop default value
-              fp.add(s"case ${f.getNumber} => {")
-                .indent
-                .add(s"val __t = $e")
-                .add({
-                  val cond =
-                    if (!f.isEnum)
-                      s"__t != ${defaultValueForGet(f, uncustomized = true)}"
-                    else
-                      s"__t.getNumber() != 0"
-                  s"if ($cond) __t else null"
-                })
-                .outdent
-                .add("}")
+                fp.add(s"case ${f.getNumber} => {")
+                  .indent
+                  .add(s"val __t = $e")
+                  .add({
+                    val cond =
+                      if (!f.isEnum)
+                        s"__t != ${defaultValueForGet(f, uncustomized = true)}"
+                      else
+                        s"__t.getNumber() != 0"
+                    s"if ($cond) __t else null"
+                  })
+                  .outdent
+                  .add("}")
               }
             } else fp.add(s"case ${f.getNumber} => $e")
         }
@@ -430,7 +432,9 @@ class ProtobufGenerator(
               val e1 = toBaseFieldTypeWithScalaDescriptors(f)
                 .andThen(singleFieldAsPvalue(f))
               val fName = fieldAccessorSymbol(f)
-              fp.add(s"case ${f.getNumber} => ${fName}.map(local_0 => ${e1.apply("local_0", enclosingType = f.enclosingType)}).getOrElse(_root_.scalapb.descriptors.PEmpty)")
+              fp.add(
+                s"case ${f.getNumber} => ${fName}.map(local_0 => ${e1.apply("local_0", enclosingType = f.enclosingType)}).getOrElse(_root_.scalapb.descriptors.PEmpty)"
+              )
             } else if (f.isRepeated) {
               fp.add(s"case ${f.getNumber} => _root_.scalapb.descriptors.PRepeated($e)")
             } else {
@@ -679,7 +683,9 @@ class ProtobufGenerator(
               .add(s"{")
               .indent
               .add(s"val __v = ${fieldNameSymbol}.map(local_0 => ${toBaseType(field)("local_0")} )")
-              .add(s"if (__v.isDefined && __v.get != ${defaultValueForGet(field, uncustomized = true)}) {")
+              .add(
+                s"if (__v.isDefined && __v.get != ${defaultValueForGet(field, uncustomized = true)}) {"
+              )
               .indent
               .call(generateWriteSingleValue(field, "__v.get"))
               .outdent
@@ -808,7 +814,8 @@ class ProtobufGenerator(
                 val expr =
                   if (field.isInOneof)
                     fieldAccessorSymbol(field)
-                  else if (field.isSealedOneofType && field.isOptional && field.getFile.isProto2 && !message.isMapEntry) s"""__${field.scalaName}.orNull"""
+                  else if (field.isSealedOneofType && field.isOptional && field.getFile.isProto2 && !message.isMapEntry)
+                    s"""__${field.scalaName}.orNull"""
                   else s"__${field.scalaName}"
                 val mappedType =
                   toBaseFieldType(field).apply(expr, field.enclosingType)
@@ -828,7 +835,8 @@ class ProtobufGenerator(
             else if (field.isInOneof) {
               s"__${field.getContainingOneof.scalaName} = ${field.oneOfTypeName}($newVal)"
             } else if (field.isRepeated) s"__${field.scalaName} += $newVal"
-            else if (field.isSealedOneofType && field.isOptional && field.getFile.isProto2 && !message.isMapEntry) s"__${field.scalaName} = Option($newVal)"
+            else if (field.isSealedOneofType && field.isOptional && field.getFile.isProto2 && !message.isMapEntry)
+              s"__${field.scalaName} = Option($newVal)"
             else s"__${field.scalaName} = $newVal"
 
           printer
@@ -1151,7 +1159,7 @@ class ProtobufGenerator(
               val lenseTpe = s"Option[${field.scalaTypeName}]"
               printer.add(
                 s"def $fieldName: ${lensType(lenseTpe)} = field(_.$fieldName)((c_, f_) => c_.copy($fieldName = f_))"
-              ) 
+              )
             } else
               printer.add(
                 s"def $fieldName: ${lensType(field.scalaTypeName)} = field(_.$fieldName)((c_, f_) => c_.copy($fieldName = f_))"
@@ -1507,7 +1515,8 @@ class ProtobufGenerator(
           _.add(
             if (message.getFile.isProto2) "" else s"case object Empty extends $sealedOneOfType",
             "",
-            if (message.getFile.isProto2) "" else s"def defaultInstance: ${sealedOneOfType} = Empty",
+            if (message.getFile.isProto2) ""
+            else s"def defaultInstance: ${sealedOneOfType} = Empty",
             "",
             s"implicit val $typeMapperName: $typeMapper = new $typeMapper {"
           ).indented(
@@ -1534,7 +1543,7 @@ class ProtobufGenerator(
                     case (fp, field) =>
                       fp.add(s"case __v: ${field.scalaTypeName} => ${field.oneOfTypeName}(__v)")
                   }.add(
-                    if (message.getFile.isProto2) { 
+                    if (message.getFile.isProto2) {
                       s"case null => ${oneof.scalaTypeName}.Empty"
                     } else {
                       s"case Empty => ${oneof.scalaTypeName}.Empty"
@@ -1597,12 +1606,16 @@ class ProtobufGenerator(
                 |def addAll${field.upperScalaName}(__vs: TraversableOnce[$singleType]): ${message.nameSymbol} = copy(${field.scalaName.asSymbol} = ${field.scalaName.asSymbol} ++ __vs)"""
               )
             }
-            .when(field.isSealedOneofType && field.isOptional && !field.isInOneof && field.getFile.isProto2 && !message.isMapEntry) {
+            .when(
+              field.isSealedOneofType && field.isOptional && !field.isInOneof && field.getFile.isProto2 && !message.isMapEntry
+            ) {
               _.add(
                 s"def $withMethod(__v: Option[${field.scalaTypeName}]): ${message.nameSymbol} = copy(${field.scalaName.asSymbol} = __v)"
               )
             }
-            .when(field.isRepeated || field.isSingular && (field.getFile.isProto3 || !field.isSealedOneofType)) {
+            .when(
+              field.isRepeated || field.isSingular && (field.getFile.isProto3 || !field.isSealedOneofType)
+            ) {
               _.add(
                 s"def $withMethod(__v: ${field.scalaTypeName}): ${message.nameSymbol} = copy(${field.scalaName.asSymbol} = __v)"
               )

--- a/e2e/src/main/protobuf/sealed_oneof_proto2.proto
+++ b/e2e/src/main/protobuf/sealed_oneof_proto2.proto
@@ -1,0 +1,55 @@
+syntax = "proto2";
+
+package com.trueaccord.proto.e2e;
+
+message Page0 {
+  optional string id = 1;
+}
+
+message Page1 {
+  required string id = 1;
+}
+
+message Page2 {
+  required string id = 1;
+  repeated PageType tpe = 2;
+}
+
+message Page3 {
+  required string id = 1;
+  optional PageType tpe = 2;
+}
+
+message Page4 {
+  required string id = 1;
+  required PageType tpe = 2;
+}
+
+message Page5 {
+  required string id = 1;
+  map<string, PageType> tpe = 2;
+}
+
+message PageWithTypeContainer {
+  required string id = 1;
+  required PageTypeContainer container = 2;
+}
+
+message PageTypeContainer {
+  oneof page_type {
+    PageType tpe1 = 1;
+    PageType tpe2 = 2;
+  }
+}
+
+message PageType {
+  oneof sealed_value {
+    SimplePage t1 = 1;
+    RedirectPage t2 = 2;
+  }
+}
+
+message SimplePage {}
+message RedirectPage {
+  required string url = 1;
+}

--- a/e2e/src/main/protobuf/sealed_oneof_proto3.proto
+++ b/e2e/src/main/protobuf/sealed_oneof_proto3.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package com.trueaccord.proto.e2e.proto3;
+
+message Page {
+  string id = 1;
+  PageType tpe = 2;
+}
+
+message PageType {
+  oneof sealed_value {
+    SimplePage t1 = 1;
+    RedirectPage t2 = 2;
+  }
+}
+
+message SimplePage {}
+message RedirectPage {
+  string url = 1;
+}

--- a/e2e/src/test/scala/SealedOneofProto2Spec.scala
+++ b/e2e/src/test/scala/SealedOneofProto2Spec.scala
@@ -1,0 +1,110 @@
+
+import org.scalatest.FreeSpec
+import com.trueaccord.proto.e2e.sealed_oneof_proto2._
+
+class SealedOneofProto2Spec extends FreeSpec {
+  "sealed trait for proto2" - {
+    "when sealed trait field is missing case 1" in {
+      val bytes = Page0(id=Some("123")).toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      assert(Page2(id="123", tpe=Seq.empty) === Page2.parseFrom(bytes))
+      assert(Page3(id="123", tpe=None) === Page3.parseFrom(bytes))
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page4.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Message missing required fields.")
+      assert(Page5(id="123", tpe=Map.empty) === Page5.parseFrom(bytes))
+    }
+
+    "when sealed trait field is missing case 2" in {
+      val bytes = Page1(id="123").toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      assert(Page2(id="123", tpe=Seq.empty) === Page2.parseFrom(bytes))
+      assert(Page3(id="123", tpe=None) === Page3.parseFrom(bytes))
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page4.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Message missing required fields.")
+      assert(Page5(id="123", tpe=Map.empty) === Page5.parseFrom(bytes))
+    }
+
+    "when sealed trait field is repeatable" in {
+      val bytes = Page2(id="123", List(SimplePage(), RedirectPage(url="/test"))).toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      assert(Page2(id="123", tpe=Seq(SimplePage(), RedirectPage(url="/test"))) === Page2.parseFrom(bytes))
+      assert(Page3(id="123", tpe=Some(RedirectPage(url="/test"))) === Page3.parseFrom(bytes))
+      assert(Page4(id="123", tpe=RedirectPage(url="/test")) === Page4.parseFrom(bytes))
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page5.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Protocol message tag had invalid wire type.")
+    }
+
+    "when sealed trait field is optional" in {
+      val bytes = Page3(id="123", Some(RedirectPage(url="/test"))).toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      assert(Page2(id="123", tpe=Seq(RedirectPage(url="/test"))) === Page2.parseFrom(bytes))
+      assert(Page3(id="123", tpe=Some(RedirectPage(url="/test"))) === Page3.parseFrom(bytes))
+      assert(Page4(id="123", tpe=RedirectPage(url="/test")) === Page4.parseFrom(bytes))
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page5.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Protocol message tag had invalid wire type.")
+    }
+
+    "when sealed trait field is required" in {
+      val bytes = Page4(id="123", RedirectPage(url="/test")).toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      assert(Page2(id="123", tpe=Seq(RedirectPage(url="/test"))) === Page2.parseFrom(bytes))
+      assert(Page3(id="123", tpe=Some(RedirectPage(url="/test"))) === Page3.parseFrom(bytes))
+      assert(Page4(id="123", tpe=RedirectPage(url="/test")) === Page4.parseFrom(bytes))
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page5.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Protocol message tag had invalid wire type.")
+    }
+
+    "when sealed trait field is map" in {
+      val bytes = Page5(id="123", Map("test1" -> RedirectPage(url="/test1"), "test2" -> RedirectPage(url="/test2"))).toByteArray
+      assert(Page0(id=Some("123")) === Page0.parseFrom(bytes))
+      assert(Page1(id="123") === Page1.parseFrom(bytes))
+      val e2 = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page2.parseFrom(bytes)
+      }
+      assert(e2.getMessage === "While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.")
+      val e3 = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page3.parseFrom(bytes)
+      }
+      assert(e3.getMessage === "While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.")
+      val e4 = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page4.parseFrom(bytes)
+      }
+      assert(e4.getMessage === "While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.")
+      assert(Page5(id="123", Map("test1" -> RedirectPage(url="/test1"), "test2" -> RedirectPage(url="/test2"))) === Page5.parseFrom(bytes))
+    }
+
+    "when sealed trait field is oneof empty" in {
+      val bytes = PageTypeContainer(PageTypeContainer.PageType.Empty).toByteArray
+      assert(PageTypeContainer(PageTypeContainer.PageType.Empty) === PageTypeContainer.parseFrom(bytes))
+    }
+
+    "when sealed trait field is oneof is not empty case 1" in {
+      val bytes1 = PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe1(SimplePage()))).toByteArray
+      val bytes2 = PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe1(RedirectPage(url="/test")))).toByteArray
+      assert(PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe1(SimplePage()))) === PageWithTypeContainer.parseFrom(bytes1))
+      assert(PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe1(RedirectPage(url="/test")))) === PageWithTypeContainer.parseFrom(bytes2))
+    }
+
+    "when sealed trait field is oneof is not empty case 2" in {
+      val bytes1 = PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe2(SimplePage()))).toByteArray
+      val bytes2 = PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe2(RedirectPage(url="/test")))).toByteArray
+      assert(PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe2(SimplePage()))) === PageWithTypeContainer.parseFrom(bytes1))
+      assert(PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe2(RedirectPage(url="/test")))) === PageWithTypeContainer.parseFrom(bytes2))
+    }
+  }
+}

--- a/e2e/src/test/scala/SealedOneofProto2Spec.scala
+++ b/e2e/src/test/scala/SealedOneofProto2Spec.scala
@@ -107,4 +107,33 @@ class SealedOneofProto2Spec extends FreeSpec {
       assert(PageWithTypeContainer(id="123", container=PageTypeContainer(PageTypeContainer.PageType.Tpe2(RedirectPage(url="/test")))) === PageWithTypeContainer.parseFrom(bytes2))
     }
   }
+
+  import com.trueaccord.proto.e2e.proto3.sealed_oneof_proto3
+  "sealed trait for proto2 should be compatible with proto3" - {
+    "when proto2 is None" in {
+      val bytes = Page3(id="123", tpe=None).toByteArray
+      val p = sealed_oneof_proto3.Page.parseFrom(bytes)
+      assert(p.tpe === sealed_oneof_proto3.PageType.Empty)
+    }
+
+    "when proto3 is Empty and proto2 is optional" in {
+      val bytes = sealed_oneof_proto3.Page(id="123", tpe=sealed_oneof_proto3.PageType.Empty).toByteArray
+      val p = Page3.parseFrom(bytes)
+      assert(p.tpe === None)
+    }
+
+    "when proto3 is Empty and proto2 is required" in {
+      val bytes = sealed_oneof_proto3.Page(id="123", tpe=sealed_oneof_proto3.PageType.Empty).toByteArray
+      val e = intercept[com.google.protobuf.InvalidProtocolBufferException] {
+        Page4.parseFrom(bytes)
+      }
+      assert(e.getMessage === "Message missing required fields.")
+    }
+
+    "when proto3 is Empty and proto2 is missing" in {
+      val bytes = Page1(id="123").toByteArray
+      val p = sealed_oneof_proto3.Page.parseFrom(bytes)
+      assert(p.tpe === sealed_oneof_proto3.PageType.Empty)
+    }
+  }
 }


### PR DESCRIPTION
For case of proto2 file

proto:
```
message PageType {
  oneof sealed_value {
    SimplePage t1 = 1;
    RedirectPage t2 = 2;
  }
}

message SimplePage {}
message RedirectPage {
  required string url = 1;
}
```

in old implementation you should always match impossible `Empty` case object in sealed trait however it useless because parseFrom will throw an exception on missing field.
proto:
```
message Page {
  required string id = 1;
  required PageType tpe = 2;
}
```
scala:
```
case class Page(id: String, tpe: PageType)
sealed trait PageType
sealed case object Empty extends PageType
case class SimplePage() extends PageType
case class RedirectPage(url: String) extends PageType
```
it can be `Empty` only if you set it with lense/copy

in this is implementation we can generate sealed trait without `Empty` case object in case of required field.
proto:
```
message Page {
  required string id = 1;
  required PageType tpe = 2;
}
```
scala:
```
case class Page(id: String, tpe: PageType)
sealed trait PageType
case class SimplePage() extends PageType
case class RedirectPage(url: String) extends PageType
```

and Option[PageType] field in case of optional where PageType sealed trait without `Empty` case object 
proto:
```
message Page {
  required string id = 1;
  optional PageType tpe = 2;
}
```
scala:
```
case class Page(id: String, tpe: Option[PageType])
sealed trait PageType
case class SimplePage() extends PageType
case class RedirectPage(url: String) extends PageType
```


