### PR TITLE
add "no default args factory methods" in companion object

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ConstructorField.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ConstructorField.scala
@@ -1,0 +1,17 @@
+package scalapb.compiler
+
+case class ConstructorField(
+    name: String,
+    typeName: String,
+    default: Option[String],
+    annotations: Seq[String] = Nil
+) {
+  def fullString: String =
+    Seq(
+      s"${if (annotations.isEmpty) "" else annotations.mkString("", " ", " ")}",
+      s"${name}: ${typeName}",
+      default.fold("")(" = " + _)
+    ).mkString
+
+  def nameAndType: String = s"${name}: ${typeName}"
+}

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/any/Any.scala
@@ -234,4 +234,11 @@ object Any extends scalapb.GeneratedMessageCompanion[com.google.protobuf.any.Any
   }
   final val TYPE_URL_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
+  def of(
+    typeUrl: _root_.scala.Predef.String,
+    value: _root_.com.google.protobuf.ByteString
+  ): _root_.com.google.protobuf.any.Any = _root_.com.google.protobuf.any.Any(
+    typeUrl,
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
@@ -329,4 +329,21 @@ object Api extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.Api
   final val SOURCE_CONTEXT_FIELD_NUMBER = 5
   final val MIXINS_FIELD_NUMBER = 6
   final val SYNTAX_FIELD_NUMBER = 7
+  def of(
+    name: _root_.scala.Predef.String,
+    methods: _root_.scala.collection.Seq[com.google.protobuf.api.Method],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    version: _root_.scala.Predef.String,
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    mixins: _root_.scala.collection.Seq[com.google.protobuf.api.Mixin],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.api.Api = _root_.com.google.protobuf.api.Api(
+    name,
+    methods,
+    options,
+    version,
+    sourceContext,
+    mixins,
+    syntax
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
@@ -314,4 +314,21 @@ object Method extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.
   final val RESPONSE_STREAMING_FIELD_NUMBER = 5
   final val OPTIONS_FIELD_NUMBER = 6
   final val SYNTAX_FIELD_NUMBER = 7
+  def of(
+    name: _root_.scala.Predef.String,
+    requestTypeUrl: _root_.scala.Predef.String,
+    requestStreaming: _root_.scala.Boolean,
+    responseTypeUrl: _root_.scala.Predef.String,
+    responseStreaming: _root_.scala.Boolean,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.api.Method = _root_.com.google.protobuf.api.Method(
+    name,
+    requestTypeUrl,
+    requestStreaming,
+    responseTypeUrl,
+    responseStreaming,
+    options,
+    syntax
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
@@ -223,4 +223,11 @@ object Mixin extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.M
   }
   final val NAME_FIELD_NUMBER = 1
   final val ROOT_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Predef.String,
+    root: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.api.Mixin = _root_.com.google.protobuf.api.Mixin(
+    name,
+    root
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -217,4 +217,15 @@ object CodeGeneratorRequest extends scalapb.GeneratedMessageCompanion[com.google
   final val PARAMETER_FIELD_NUMBER = 2
   final val PROTO_FILE_FIELD_NUMBER = 15
   final val COMPILER_VERSION_FIELD_NUMBER = 3
+  def of(
+    fileToGenerate: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    parameter: _root_.scala.Option[_root_.scala.Predef.String],
+    protoFile: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto],
+    compilerVersion: _root_.scala.Option[com.google.protobuf.compiler.plugin.Version]
+  ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorRequest = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorRequest(
+    fileToGenerate,
+    parameter,
+    protoFile,
+    compilerVersion
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -349,6 +349,15 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
     final val NAME_FIELD_NUMBER = 1
     final val INSERTION_POINT_FIELD_NUMBER = 2
     final val CONTENT_FIELD_NUMBER = 15
+    def of(
+      name: _root_.scala.Option[_root_.scala.Predef.String],
+      insertionPoint: _root_.scala.Option[_root_.scala.Predef.String],
+      content: _root_.scala.Option[_root_.scala.Predef.String]
+    ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File(
+      name,
+      insertionPoint,
+      content
+    )
   }
   
   implicit class CodeGeneratorResponseLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.compiler.plugin.CodeGeneratorResponse]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.compiler.plugin.CodeGeneratorResponse](_l) {
@@ -358,4 +367,11 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
   }
   final val ERROR_FIELD_NUMBER = 1
   final val FILE_FIELD_NUMBER = 15
+  def of(
+    error: _root_.scala.Option[_root_.scala.Predef.String],
+    file: _root_.scala.collection.Seq[com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File]
+  ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse(
+    error,
+    file
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
@@ -185,4 +185,15 @@ object Version extends scalapb.GeneratedMessageCompanion[com.google.protobuf.com
   final val MINOR_FIELD_NUMBER = 2
   final val PATCH_FIELD_NUMBER = 3
   final val SUFFIX_FIELD_NUMBER = 4
+  def of(
+    major: _root_.scala.Option[_root_.scala.Int],
+    minor: _root_.scala.Option[_root_.scala.Int],
+    patch: _root_.scala.Option[_root_.scala.Int],
+    suffix: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.compiler.plugin.Version = _root_.com.google.protobuf.compiler.plugin.Version(
+    major,
+    minor,
+    patch,
+    suffix
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -468,6 +468,13 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
     }
     final val START_FIELD_NUMBER = 1
     final val END_FIELD_NUMBER = 2
+    def of(
+      start: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.DescriptorProto.ExtensionRange = _root_.com.google.protobuf.descriptor.DescriptorProto.ExtensionRange(
+      start,
+      end
+    )
   }
   
   /** Range of reserved tag numbers. Reserved tag numbers may not be used by
@@ -603,6 +610,13 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
     }
     final val START_FIELD_NUMBER = 1
     final val END_FIELD_NUMBER = 2
+    def of(
+      start: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.DescriptorProto.ReservedRange = _root_.com.google.protobuf.descriptor.DescriptorProto.ReservedRange(
+      start,
+      end
+    )
   }
   
   implicit class DescriptorProtoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.DescriptorProto]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.DescriptorProto](_l) {
@@ -629,4 +643,27 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
   final val OPTIONS_FIELD_NUMBER = 7
   final val RESERVED_RANGE_FIELD_NUMBER = 9
   final val RESERVED_NAME_FIELD_NUMBER = 10
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    field: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    extension: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    nestedType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto],
+    enumType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumDescriptorProto],
+    extensionRange: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto.ExtensionRange],
+    oneofDecl: _root_.scala.collection.Seq[com.google.protobuf.descriptor.OneofDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.MessageOptions],
+    reservedRange: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto.ReservedRange],
+    reservedName: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.DescriptorProto = _root_.com.google.protobuf.descriptor.DescriptorProto(
+    name,
+    field,
+    extension,
+    nestedType,
+    enumType,
+    extensionRange,
+    oneofDecl,
+    options,
+    reservedRange,
+    reservedName
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -168,4 +168,13 @@ object EnumDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   final val NAME_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    value: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumValueDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.EnumOptions]
+  ): _root_.com.google.protobuf.descriptor.EnumDescriptorProto = _root_.com.google.protobuf.descriptor.EnumDescriptorProto(
+    name,
+    value,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
@@ -181,4 +181,15 @@ object EnumOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   final val ALLOW_ALIAS_FIELD_NUMBER = 2
   final val DEPRECATED_FIELD_NUMBER = 3
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    allowAlias: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.EnumOptions = _root_.com.google.protobuf.descriptor.EnumOptions(
+    allowAlias,
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -164,4 +164,13 @@ object EnumValueDescriptorProto extends scalapb.GeneratedMessageCompanion[com.go
   final val NAME_FIELD_NUMBER = 1
   final val NUMBER_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    number: _root_.scala.Option[_root_.scala.Int],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.EnumValueOptions]
+  ): _root_.com.google.protobuf.descriptor.EnumValueDescriptorProto = _root_.com.google.protobuf.descriptor.EnumValueDescriptorProto(
+    name,
+    number,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -153,4 +153,13 @@ object EnumValueOptions extends scalapb.GeneratedMessageCompanion[com.google.pro
   }
   final val DEPRECATED_FIELD_NUMBER = 1
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.EnumValueOptions = _root_.com.google.protobuf.descriptor.EnumValueOptions(
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -625,4 +625,27 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   final val ONEOF_INDEX_FIELD_NUMBER = 9
   final val JSON_NAME_FIELD_NUMBER = 10
   final val OPTIONS_FIELD_NUMBER = 8
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    number: _root_.scala.Option[_root_.scala.Int],
+    label: _root_.scala.Option[com.google.protobuf.descriptor.FieldDescriptorProto.Label],
+    `type`: _root_.scala.Option[com.google.protobuf.descriptor.FieldDescriptorProto.Type],
+    typeName: _root_.scala.Option[_root_.scala.Predef.String],
+    extendee: _root_.scala.Option[_root_.scala.Predef.String],
+    defaultValue: _root_.scala.Option[_root_.scala.Predef.String],
+    oneofIndex: _root_.scala.Option[_root_.scala.Int],
+    jsonName: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions]
+  ): _root_.com.google.protobuf.descriptor.FieldDescriptorProto = _root_.com.google.protobuf.descriptor.FieldDescriptorProto(
+    name,
+    number,
+    label,
+    `type`,
+    typeName,
+    extendee,
+    defaultValue,
+    oneofIndex,
+    jsonName,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -439,4 +439,23 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   final val DEPRECATED_FIELD_NUMBER = 3
   final val WEAK_FIELD_NUMBER = 10
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    ctype: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions.CType],
+    packed: _root_.scala.Option[_root_.scala.Boolean],
+    jstype: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions.JSType],
+    `lazy`: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    weak: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.FieldOptions = _root_.com.google.protobuf.descriptor.FieldOptions(
+    ctype,
+    packed,
+    jstype,
+    `lazy`,
+    deprecated,
+    weak,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -443,4 +443,31 @@ object FileDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   final val OPTIONS_FIELD_NUMBER = 8
   final val SOURCE_CODE_INFO_FIELD_NUMBER = 9
   final val SYNTAX_FIELD_NUMBER = 12
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    `package`: _root_.scala.Option[_root_.scala.Predef.String],
+    dependency: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    publicDependency: _root_.scala.collection.Seq[_root_.scala.Int],
+    weakDependency: _root_.scala.collection.Seq[_root_.scala.Int],
+    messageType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto],
+    enumType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumDescriptorProto],
+    service: _root_.scala.collection.Seq[com.google.protobuf.descriptor.ServiceDescriptorProto],
+    extension: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.FileOptions],
+    sourceCodeInfo: _root_.scala.Option[com.google.protobuf.descriptor.SourceCodeInfo],
+    syntax: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.FileDescriptorProto = _root_.com.google.protobuf.descriptor.FileDescriptorProto(
+    name,
+    `package`,
+    dependency,
+    publicDependency,
+    weakDependency,
+    messageType,
+    enumType,
+    service,
+    extension,
+    options,
+    sourceCodeInfo,
+    syntax
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -116,4 +116,9 @@ object FileDescriptorSet extends scalapb.GeneratedMessageCompanion[com.google.pr
     def file: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto]] = field(_.file)((c_, f_) => c_.copy(file = f_))
   }
   final val FILE_FIELD_NUMBER = 1
+  def of(
+    file: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto]
+  ): _root_.com.google.protobuf.descriptor.FileDescriptorSet = _root_.com.google.protobuf.descriptor.FileDescriptorSet(
+    file
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -644,4 +644,43 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   final val SWIFT_PREFIX_FIELD_NUMBER = 39
   final val PHP_CLASS_PREFIX_FIELD_NUMBER = 40
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    javaPackage: _root_.scala.Option[_root_.scala.Predef.String],
+    javaOuterClassname: _root_.scala.Option[_root_.scala.Predef.String],
+    javaMultipleFiles: _root_.scala.Option[_root_.scala.Boolean],
+    javaGenerateEqualsAndHash: _root_.scala.Option[_root_.scala.Boolean],
+    javaStringCheckUtf8: _root_.scala.Option[_root_.scala.Boolean],
+    optimizeFor: _root_.scala.Option[com.google.protobuf.descriptor.FileOptions.OptimizeMode],
+    goPackage: _root_.scala.Option[_root_.scala.Predef.String],
+    ccGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    javaGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    pyGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    ccEnableArenas: _root_.scala.Option[_root_.scala.Boolean],
+    objcClassPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    csharpNamespace: _root_.scala.Option[_root_.scala.Predef.String],
+    swiftPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    phpClassPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.FileOptions = _root_.com.google.protobuf.descriptor.FileOptions(
+    javaPackage,
+    javaOuterClassname,
+    javaMultipleFiles,
+    javaGenerateEqualsAndHash,
+    javaStringCheckUtf8,
+    optimizeFor,
+    goPackage,
+    ccGenericServices,
+    javaGenericServices,
+    pyGenericServices,
+    deprecated,
+    ccEnableArenas,
+    objcClassPrefix,
+    csharpNamespace,
+    swiftPrefix,
+    phpClassPrefix,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -324,10 +324,26 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
     final val SOURCE_FILE_FIELD_NUMBER = 2
     final val BEGIN_FIELD_NUMBER = 3
     final val END_FIELD_NUMBER = 4
+    def of(
+      path: _root_.scala.collection.Seq[_root_.scala.Int],
+      sourceFile: _root_.scala.Option[_root_.scala.Predef.String],
+      begin: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation = _root_.com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation(
+      path,
+      sourceFile,
+      begin,
+      end
+    )
   }
   
   implicit class GeneratedCodeInfoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.GeneratedCodeInfo]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.GeneratedCodeInfo](_l) {
     def annotation: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation]] = field(_.annotation)((c_, f_) => c_.copy(annotation = f_))
   }
   final val ANNOTATION_FIELD_NUMBER = 1
+  def of(
+    annotation: _root_.scala.collection.Seq[com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation]
+  ): _root_.com.google.protobuf.descriptor.GeneratedCodeInfo = _root_.com.google.protobuf.descriptor.GeneratedCodeInfo(
+    annotation
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
@@ -273,4 +273,19 @@ object MessageOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   final val DEPRECATED_FIELD_NUMBER = 3
   final val MAP_ENTRY_FIELD_NUMBER = 7
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    messageSetWireFormat: _root_.scala.Option[_root_.scala.Boolean],
+    noStandardDescriptorAccessor: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    mapEntry: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.MessageOptions = _root_.com.google.protobuf.descriptor.MessageOptions(
+    messageSetWireFormat,
+    noStandardDescriptorAccessor,
+    deprecated,
+    mapEntry,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -247,4 +247,19 @@ object MethodDescriptorProto extends scalapb.GeneratedMessageCompanion[com.googl
   final val OPTIONS_FIELD_NUMBER = 4
   final val CLIENT_STREAMING_FIELD_NUMBER = 5
   final val SERVER_STREAMING_FIELD_NUMBER = 6
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    inputType: _root_.scala.Option[_root_.scala.Predef.String],
+    outputType: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.MethodOptions],
+    clientStreaming: _root_.scala.Option[_root_.scala.Boolean],
+    serverStreaming: _root_.scala.Option[_root_.scala.Boolean]
+  ): _root_.com.google.protobuf.descriptor.MethodDescriptorProto = _root_.com.google.protobuf.descriptor.MethodDescriptorProto(
+    name,
+    inputType,
+    outputType,
+    options,
+    clientStreaming,
+    serverStreaming
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -234,4 +234,15 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
   final val DEPRECATED_FIELD_NUMBER = 33
   final val IDEMPOTENCY_LEVEL_FIELD_NUMBER = 34
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    idempotencyLevel: _root_.scala.Option[com.google.protobuf.descriptor.MethodOptions.IdempotencyLevel],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.MethodOptions = _root_.com.google.protobuf.descriptor.MethodOptions(
+    deprecated,
+    idempotencyLevel,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -139,4 +139,11 @@ object OneofDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   }
   final val NAME_FIELD_NUMBER = 1
   final val OPTIONS_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.OneofOptions]
+  ): _root_.com.google.protobuf.descriptor.OneofDescriptorProto = _root_.com.google.protobuf.descriptor.OneofDescriptorProto(
+    name,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
@@ -123,4 +123,11 @@ object OneofOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
     def uninterpretedOption: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption]] = field(_.uninterpretedOption)((c_, f_) => c_.copy(uninterpretedOption = f_))
   }
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.OneofOptions = _root_.com.google.protobuf.descriptor.OneofOptions(
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -168,4 +168,13 @@ object ServiceDescriptorProto extends scalapb.GeneratedMessageCompanion[com.goog
   final val NAME_FIELD_NUMBER = 1
   final val METHOD_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    method: _root_.scala.collection.Seq[com.google.protobuf.descriptor.MethodDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.ServiceOptions]
+  ): _root_.com.google.protobuf.descriptor.ServiceDescriptorProto = _root_.com.google.protobuf.descriptor.ServiceDescriptorProto(
+    name,
+    method,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -153,4 +153,13 @@ object ServiceOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   }
   final val DEPRECATED_FIELD_NUMBER = 33
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.ServiceOptions = _root_.com.google.protobuf.descriptor.ServiceOptions(
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -473,10 +473,28 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
     final val LEADING_COMMENTS_FIELD_NUMBER = 3
     final val TRAILING_COMMENTS_FIELD_NUMBER = 4
     final val LEADING_DETACHED_COMMENTS_FIELD_NUMBER = 6
+    def of(
+      path: _root_.scala.collection.Seq[_root_.scala.Int],
+      span: _root_.scala.collection.Seq[_root_.scala.Int],
+      leadingComments: _root_.scala.Option[_root_.scala.Predef.String],
+      trailingComments: _root_.scala.Option[_root_.scala.Predef.String],
+      leadingDetachedComments: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+    ): _root_.com.google.protobuf.descriptor.SourceCodeInfo.Location = _root_.com.google.protobuf.descriptor.SourceCodeInfo.Location(
+      path,
+      span,
+      leadingComments,
+      trailingComments,
+      leadingDetachedComments
+    )
   }
   
   implicit class SourceCodeInfoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.SourceCodeInfo]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.SourceCodeInfo](_l) {
     def location: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.SourceCodeInfo.Location]] = field(_.location)((c_, f_) => c_.copy(location = f_))
   }
   final val LOCATION_FIELD_NUMBER = 1
+  def of(
+    location: _root_.scala.collection.Seq[com.google.protobuf.descriptor.SourceCodeInfo.Location]
+  ): _root_.com.google.protobuf.descriptor.SourceCodeInfo = _root_.com.google.protobuf.descriptor.SourceCodeInfo(
+    location
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -388,6 +388,13 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
     }
     final val NAME_PART_FIELD_NUMBER = 1
     final val IS_EXTENSION_FIELD_NUMBER = 2
+    def of(
+      namePart: _root_.scala.Predef.String,
+      isExtension: _root_.scala.Boolean
+    ): _root_.com.google.protobuf.descriptor.UninterpretedOption.NamePart = _root_.com.google.protobuf.descriptor.UninterpretedOption.NamePart(
+      namePart,
+      isExtension
+    )
   }
   
   implicit class UninterpretedOptionLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.UninterpretedOption]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.UninterpretedOption](_l) {
@@ -412,4 +419,21 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
   final val DOUBLE_VALUE_FIELD_NUMBER = 6
   final val STRING_VALUE_FIELD_NUMBER = 7
   final val AGGREGATE_VALUE_FIELD_NUMBER = 8
+  def of(
+    name: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption.NamePart],
+    identifierValue: _root_.scala.Option[_root_.scala.Predef.String],
+    positiveIntValue: _root_.scala.Option[_root_.scala.Long],
+    negativeIntValue: _root_.scala.Option[_root_.scala.Long],
+    doubleValue: _root_.scala.Option[_root_.scala.Double],
+    stringValue: _root_.scala.Option[_root_.com.google.protobuf.ByteString],
+    aggregateValue: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.UninterpretedOption = _root_.com.google.protobuf.descriptor.UninterpretedOption(
+    name,
+    identifierValue,
+    positiveIntValue,
+    negativeIntValue,
+    doubleValue,
+    stringValue,
+    aggregateValue
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
@@ -210,4 +210,11 @@ object Duration extends scalapb.GeneratedMessageCompanion[com.google.protobuf.du
   }
   final val SECONDS_FIELD_NUMBER = 1
   final val NANOS_FIELD_NUMBER = 2
+  def of(
+    seconds: _root_.scala.Long,
+    nanos: _root_.scala.Int
+  ): _root_.com.google.protobuf.duration.Duration = _root_.com.google.protobuf.duration.Duration(
+    seconds,
+    nanos
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
@@ -68,4 +68,7 @@ object Empty extends scalapb.GeneratedMessageCompanion[com.google.protobuf.empty
   )
   implicit class EmptyLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.empty.Empty]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.empty.Empty](_l) {
   }
+  def of(
+  ): _root_.com.google.protobuf.empty.Empty = _root_.com.google.protobuf.empty.Empty(
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
@@ -310,4 +310,9 @@ object FieldMask extends scalapb.GeneratedMessageCompanion[com.google.protobuf.f
     def paths: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[_root_.scala.Predef.String]] = field(_.paths)((c_, f_) => c_.copy(paths = f_))
   }
   final val PATHS_FIELD_NUMBER = 1
+  def of(
+    paths: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.field_mask.FieldMask = _root_.com.google.protobuf.field_mask.FieldMask(
+    paths
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
@@ -116,4 +116,9 @@ object SourceContext extends scalapb.GeneratedMessageCompanion[com.google.protob
     def fileName: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.fileName)((c_, f_) => c_.copy(fileName = f_))
   }
   final val FILE_NAME_FIELD_NUMBER = 1
+  def of(
+    fileName: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.source_context.SourceContext = _root_.com.google.protobuf.source_context.SourceContext(
+    fileName
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
@@ -120,4 +120,9 @@ object ListValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.s
     def values: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.struct.Value]] = field(_.values)((c_, f_) => c_.copy(values = f_))
   }
   final val VALUES_FIELD_NUMBER = 1
+  def of(
+    values: _root_.scala.collection.Seq[com.google.protobuf.struct.Value]
+  ): _root_.com.google.protobuf.struct.ListValue = _root_.com.google.protobuf.struct.ListValue(
+    values
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
@@ -258,6 +258,13 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
     final val VALUE_FIELD_NUMBER = 2
     implicit val keyValueMapper: _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)] =
       _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)](__m => (__m.key, __m.getValue))(__p => com.google.protobuf.struct.Struct.FieldsEntry(__p._1, Some(__p._2)))
+    def of(
+      key: _root_.scala.Predef.String,
+      value: _root_.scala.Option[com.google.protobuf.struct.Value]
+    ): _root_.com.google.protobuf.struct.Struct.FieldsEntry = _root_.com.google.protobuf.struct.Struct.FieldsEntry(
+      key,
+      value
+    )
   }
   
   implicit class StructLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.struct.Struct]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.struct.Struct](_l) {
@@ -266,4 +273,9 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
   final val FIELDS_FIELD_NUMBER = 1
   @transient
   private val _typemapper_fields: _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)] = implicitly[_root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)]]
+  def of(
+    fields: scala.collection.immutable.Map[_root_.scala.Predef.String, com.google.protobuf.struct.Value]
+  ): _root_.com.google.protobuf.struct.Struct = _root_.com.google.protobuf.struct.Struct(
+    fields
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
@@ -301,4 +301,9 @@ object Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.struc
   final val BOOL_VALUE_FIELD_NUMBER = 4
   final val STRUCT_VALUE_FIELD_NUMBER = 5
   final val LIST_VALUE_FIELD_NUMBER = 6
+  def of(
+    kind: com.google.protobuf.struct.Value.Kind
+  ): _root_.com.google.protobuf.struct.Value = _root_.com.google.protobuf.struct.Value(
+    kind
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
@@ -226,4 +226,11 @@ object Timestamp extends scalapb.GeneratedMessageCompanion[com.google.protobuf.t
   }
   final val SECONDS_FIELD_NUMBER = 1
   final val NANOS_FIELD_NUMBER = 2
+  def of(
+    seconds: _root_.scala.Long,
+    nanos: _root_.scala.Int
+  ): _root_.com.google.protobuf.timestamp.Timestamp = _root_.com.google.protobuf.timestamp.Timestamp(
+    seconds,
+    nanos
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
@@ -246,4 +246,17 @@ object Enum extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   final val OPTIONS_FIELD_NUMBER = 3
   final val SOURCE_CONTEXT_FIELD_NUMBER = 4
   final val SYNTAX_FIELD_NUMBER = 5
+  def of(
+    name: _root_.scala.Predef.String,
+    enumvalue: _root_.scala.collection.Seq[com.google.protobuf.`type`.EnumValue],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.`type`.Enum = _root_.com.google.protobuf.`type`.Enum(
+    name,
+    enumvalue,
+    options,
+    sourceContext,
+    syntax
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
@@ -182,4 +182,13 @@ object EnumValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`
   final val NAME_FIELD_NUMBER = 1
   final val NUMBER_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Predef.String,
+    number: _root_.scala.Int,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto]
+  ): _root_.com.google.protobuf.`type`.EnumValue = _root_.com.google.protobuf.`type`.EnumValue(
+    name,
+    number,
+    options
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -687,4 +687,27 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   final val OPTIONS_FIELD_NUMBER = 9
   final val JSON_NAME_FIELD_NUMBER = 10
   final val DEFAULT_VALUE_FIELD_NUMBER = 11
+  def of(
+    kind: com.google.protobuf.`type`.Field.Kind,
+    cardinality: com.google.protobuf.`type`.Field.Cardinality,
+    number: _root_.scala.Int,
+    name: _root_.scala.Predef.String,
+    typeUrl: _root_.scala.Predef.String,
+    oneofIndex: _root_.scala.Int,
+    packed: _root_.scala.Boolean,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    jsonName: _root_.scala.Predef.String,
+    defaultValue: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.`type`.Field = _root_.com.google.protobuf.`type`.Field(
+    kind,
+    cardinality,
+    number,
+    name,
+    typeUrl,
+    oneofIndex,
+    packed,
+    options,
+    jsonName,
+    defaultValue
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
@@ -156,4 +156,11 @@ object OptionProto extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   }
   final val NAME_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Predef.String,
+    value: _root_.scala.Option[com.google.protobuf.any.Any]
+  ): _root_.com.google.protobuf.`type`.OptionProto = _root_.com.google.protobuf.`type`.OptionProto(
+    name,
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
@@ -273,4 +273,19 @@ object Type extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   final val OPTIONS_FIELD_NUMBER = 4
   final val SOURCE_CONTEXT_FIELD_NUMBER = 5
   final val SYNTAX_FIELD_NUMBER = 6
+  def of(
+    name: _root_.scala.Predef.String,
+    fields: _root_.scala.collection.Seq[com.google.protobuf.`type`.Field],
+    oneofs: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.`type`.Type = _root_.com.google.protobuf.`type`.Type(
+    name,
+    fields,
+    oneofs,
+    options,
+    sourceContext,
+    syntax
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
@@ -116,4 +116,9 @@ object BoolValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.w
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Boolean] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Boolean
+  ): _root_.com.google.protobuf.wrappers.BoolValue = _root_.com.google.protobuf.wrappers.BoolValue(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
@@ -116,4 +116,9 @@ object BytesValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.com.google.protobuf.ByteString] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.com.google.protobuf.ByteString
+  ): _root_.com.google.protobuf.wrappers.BytesValue = _root_.com.google.protobuf.wrappers.BytesValue(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
@@ -116,4 +116,9 @@ object DoubleValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Double] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Double
+  ): _root_.com.google.protobuf.wrappers.DoubleValue = _root_.com.google.protobuf.wrappers.DoubleValue(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
@@ -116,4 +116,9 @@ object FloatValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Float] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Float
+  ): _root_.com.google.protobuf.wrappers.FloatValue = _root_.com.google.protobuf.wrappers.FloatValue(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
@@ -116,4 +116,9 @@ object Int32Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Int] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Int
+  ): _root_.com.google.protobuf.wrappers.Int32Value = _root_.com.google.protobuf.wrappers.Int32Value(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
@@ -116,4 +116,9 @@ object Int64Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Long] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Long
+  ): _root_.com.google.protobuf.wrappers.Int64Value = _root_.com.google.protobuf.wrappers.Int64Value(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
@@ -116,4 +116,9 @@ object StringValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.wrappers.StringValue = _root_.com.google.protobuf.wrappers.StringValue(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
@@ -116,4 +116,9 @@ object UInt32Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Int] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Int
+  ): _root_.com.google.protobuf.wrappers.UInt32Value = _root_.com.google.protobuf.wrappers.UInt32Value(
+    value
+  )
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
@@ -116,4 +116,9 @@ object UInt64Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Long] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Long
+  ): _root_.com.google.protobuf.wrappers.UInt64Value = _root_.com.google.protobuf.wrappers.UInt64Value(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/any/Any.scala
@@ -224,4 +224,11 @@ object Any extends scalapb.GeneratedMessageCompanion[com.google.protobuf.any.Any
   }
   final val TYPE_URL_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
+  def of(
+    typeUrl: _root_.scala.Predef.String,
+    value: _root_.com.google.protobuf.ByteString
+  ): _root_.com.google.protobuf.any.Any = _root_.com.google.protobuf.any.Any(
+    typeUrl,
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Api.scala
@@ -308,4 +308,21 @@ object Api extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.Api
   final val SOURCE_CONTEXT_FIELD_NUMBER = 5
   final val MIXINS_FIELD_NUMBER = 6
   final val SYNTAX_FIELD_NUMBER = 7
+  def of(
+    name: _root_.scala.Predef.String,
+    methods: _root_.scala.collection.Seq[com.google.protobuf.api.Method],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    version: _root_.scala.Predef.String,
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    mixins: _root_.scala.collection.Seq[com.google.protobuf.api.Mixin],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.api.Api = _root_.com.google.protobuf.api.Api(
+    name,
+    methods,
+    options,
+    version,
+    sourceContext,
+    mixins,
+    syntax
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Method.scala
@@ -293,4 +293,21 @@ object Method extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.
   final val RESPONSE_STREAMING_FIELD_NUMBER = 5
   final val OPTIONS_FIELD_NUMBER = 6
   final val SYNTAX_FIELD_NUMBER = 7
+  def of(
+    name: _root_.scala.Predef.String,
+    requestTypeUrl: _root_.scala.Predef.String,
+    requestStreaming: _root_.scala.Boolean,
+    responseTypeUrl: _root_.scala.Predef.String,
+    responseStreaming: _root_.scala.Boolean,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.api.Method = _root_.com.google.protobuf.api.Method(
+    name,
+    requestTypeUrl,
+    requestStreaming,
+    responseTypeUrl,
+    responseStreaming,
+    options,
+    syntax
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/api/Mixin.scala
@@ -213,4 +213,11 @@ object Mixin extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.M
   }
   final val NAME_FIELD_NUMBER = 1
   final val ROOT_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Predef.String,
+    root: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.api.Mixin = _root_.com.google.protobuf.api.Mixin(
+    name,
+    root
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -202,4 +202,15 @@ object CodeGeneratorRequest extends scalapb.GeneratedMessageCompanion[com.google
   final val PARAMETER_FIELD_NUMBER = 2
   final val PROTO_FILE_FIELD_NUMBER = 15
   final val COMPILER_VERSION_FIELD_NUMBER = 3
+  def of(
+    fileToGenerate: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    parameter: _root_.scala.Option[_root_.scala.Predef.String],
+    protoFile: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto],
+    compilerVersion: _root_.scala.Option[com.google.protobuf.compiler.plugin.Version]
+  ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorRequest = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorRequest(
+    fileToGenerate,
+    parameter,
+    protoFile,
+    compilerVersion
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -326,6 +326,15 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
     final val NAME_FIELD_NUMBER = 1
     final val INSERTION_POINT_FIELD_NUMBER = 2
     final val CONTENT_FIELD_NUMBER = 15
+    def of(
+      name: _root_.scala.Option[_root_.scala.Predef.String],
+      insertionPoint: _root_.scala.Option[_root_.scala.Predef.String],
+      content: _root_.scala.Option[_root_.scala.Predef.String]
+    ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File(
+      name,
+      insertionPoint,
+      content
+    )
   }
   
   implicit class CodeGeneratorResponseLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.compiler.plugin.CodeGeneratorResponse]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.compiler.plugin.CodeGeneratorResponse](_l) {
@@ -335,4 +344,11 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
   }
   final val ERROR_FIELD_NUMBER = 1
   final val FILE_FIELD_NUMBER = 15
+  def of(
+    error: _root_.scala.Option[_root_.scala.Predef.String],
+    file: _root_.scala.collection.Seq[com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File]
+  ): _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse = _root_.com.google.protobuf.compiler.plugin.CodeGeneratorResponse(
+    error,
+    file
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/compiler/plugin/Version.scala
@@ -171,4 +171,15 @@ object Version extends scalapb.GeneratedMessageCompanion[com.google.protobuf.com
   final val MINOR_FIELD_NUMBER = 2
   final val PATCH_FIELD_NUMBER = 3
   final val SUFFIX_FIELD_NUMBER = 4
+  def of(
+    major: _root_.scala.Option[_root_.scala.Int],
+    minor: _root_.scala.Option[_root_.scala.Int],
+    patch: _root_.scala.Option[_root_.scala.Int],
+    suffix: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.compiler.plugin.Version = _root_.com.google.protobuf.compiler.plugin.Version(
+    major,
+    minor,
+    patch,
+    suffix
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -431,6 +431,13 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
     }
     final val START_FIELD_NUMBER = 1
     final val END_FIELD_NUMBER = 2
+    def of(
+      start: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.DescriptorProto.ExtensionRange = _root_.com.google.protobuf.descriptor.DescriptorProto.ExtensionRange(
+      start,
+      end
+    )
   }
   
   /** Range of reserved tag numbers. Reserved tag numbers may not be used by
@@ -556,6 +563,13 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
     }
     final val START_FIELD_NUMBER = 1
     final val END_FIELD_NUMBER = 2
+    def of(
+      start: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.DescriptorProto.ReservedRange = _root_.com.google.protobuf.descriptor.DescriptorProto.ReservedRange(
+      start,
+      end
+    )
   }
   
   implicit class DescriptorProtoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.DescriptorProto]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.DescriptorProto](_l) {
@@ -582,4 +596,27 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
   final val OPTIONS_FIELD_NUMBER = 7
   final val RESERVED_RANGE_FIELD_NUMBER = 9
   final val RESERVED_NAME_FIELD_NUMBER = 10
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    field: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    extension: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    nestedType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto],
+    enumType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumDescriptorProto],
+    extensionRange: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto.ExtensionRange],
+    oneofDecl: _root_.scala.collection.Seq[com.google.protobuf.descriptor.OneofDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.MessageOptions],
+    reservedRange: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto.ReservedRange],
+    reservedName: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.DescriptorProto = _root_.com.google.protobuf.descriptor.DescriptorProto(
+    name,
+    field,
+    extension,
+    nestedType,
+    enumType,
+    extensionRange,
+    oneofDecl,
+    options,
+    reservedRange,
+    reservedName
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -155,4 +155,13 @@ object EnumDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   final val NAME_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    value: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumValueDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.EnumOptions]
+  ): _root_.com.google.protobuf.descriptor.EnumDescriptorProto = _root_.com.google.protobuf.descriptor.EnumDescriptorProto(
+    name,
+    value,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
@@ -168,4 +168,15 @@ object EnumOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   final val ALLOW_ALIAS_FIELD_NUMBER = 2
   final val DEPRECATED_FIELD_NUMBER = 3
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    allowAlias: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.EnumOptions = _root_.com.google.protobuf.descriptor.EnumOptions(
+    allowAlias,
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -152,4 +152,13 @@ object EnumValueDescriptorProto extends scalapb.GeneratedMessageCompanion[com.go
   final val NAME_FIELD_NUMBER = 1
   final val NUMBER_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    number: _root_.scala.Option[_root_.scala.Int],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.EnumValueOptions]
+  ): _root_.com.google.protobuf.descriptor.EnumValueDescriptorProto = _root_.com.google.protobuf.descriptor.EnumValueDescriptorProto(
+    name,
+    number,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -142,4 +142,13 @@ object EnumValueOptions extends scalapb.GeneratedMessageCompanion[com.google.pro
   }
   final val DEPRECATED_FIELD_NUMBER = 1
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.EnumValueOptions = _root_.com.google.protobuf.descriptor.EnumValueOptions(
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -589,4 +589,27 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   final val ONEOF_INDEX_FIELD_NUMBER = 9
   final val JSON_NAME_FIELD_NUMBER = 10
   final val OPTIONS_FIELD_NUMBER = 8
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    number: _root_.scala.Option[_root_.scala.Int],
+    label: _root_.scala.Option[com.google.protobuf.descriptor.FieldDescriptorProto.Label],
+    `type`: _root_.scala.Option[com.google.protobuf.descriptor.FieldDescriptorProto.Type],
+    typeName: _root_.scala.Option[_root_.scala.Predef.String],
+    extendee: _root_.scala.Option[_root_.scala.Predef.String],
+    defaultValue: _root_.scala.Option[_root_.scala.Predef.String],
+    oneofIndex: _root_.scala.Option[_root_.scala.Int],
+    jsonName: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions]
+  ): _root_.com.google.protobuf.descriptor.FieldDescriptorProto = _root_.com.google.protobuf.descriptor.FieldDescriptorProto(
+    name,
+    number,
+    label,
+    `type`,
+    typeName,
+    extendee,
+    defaultValue,
+    oneofIndex,
+    jsonName,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -408,4 +408,23 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   final val DEPRECATED_FIELD_NUMBER = 3
   final val WEAK_FIELD_NUMBER = 10
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    ctype: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions.CType],
+    packed: _root_.scala.Option[_root_.scala.Boolean],
+    jstype: _root_.scala.Option[com.google.protobuf.descriptor.FieldOptions.JSType],
+    `lazy`: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    weak: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.FieldOptions = _root_.com.google.protobuf.descriptor.FieldOptions(
+    ctype,
+    packed,
+    jstype,
+    `lazy`,
+    deprecated,
+    weak,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -412,4 +412,31 @@ object FileDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   final val OPTIONS_FIELD_NUMBER = 8
   final val SOURCE_CODE_INFO_FIELD_NUMBER = 9
   final val SYNTAX_FIELD_NUMBER = 12
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    `package`: _root_.scala.Option[_root_.scala.Predef.String],
+    dependency: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    publicDependency: _root_.scala.collection.Seq[_root_.scala.Int],
+    weakDependency: _root_.scala.collection.Seq[_root_.scala.Int],
+    messageType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.DescriptorProto],
+    enumType: _root_.scala.collection.Seq[com.google.protobuf.descriptor.EnumDescriptorProto],
+    service: _root_.scala.collection.Seq[com.google.protobuf.descriptor.ServiceDescriptorProto],
+    extension: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FieldDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.FileOptions],
+    sourceCodeInfo: _root_.scala.Option[com.google.protobuf.descriptor.SourceCodeInfo],
+    syntax: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.FileDescriptorProto = _root_.com.google.protobuf.descriptor.FileDescriptorProto(
+    name,
+    `package`,
+    dependency,
+    publicDependency,
+    weakDependency,
+    messageType,
+    enumType,
+    service,
+    extension,
+    options,
+    sourceCodeInfo,
+    syntax
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -107,4 +107,9 @@ object FileDescriptorSet extends scalapb.GeneratedMessageCompanion[com.google.pr
     def file: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto]] = field(_.file)((c_, f_) => c_.copy(file = f_))
   }
   final val FILE_FIELD_NUMBER = 1
+  def of(
+    file: _root_.scala.collection.Seq[com.google.protobuf.descriptor.FileDescriptorProto]
+  ): _root_.com.google.protobuf.descriptor.FileDescriptorSet = _root_.com.google.protobuf.descriptor.FileDescriptorSet(
+    file
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -598,4 +598,43 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   final val SWIFT_PREFIX_FIELD_NUMBER = 39
   final val PHP_CLASS_PREFIX_FIELD_NUMBER = 40
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    javaPackage: _root_.scala.Option[_root_.scala.Predef.String],
+    javaOuterClassname: _root_.scala.Option[_root_.scala.Predef.String],
+    javaMultipleFiles: _root_.scala.Option[_root_.scala.Boolean],
+    javaGenerateEqualsAndHash: _root_.scala.Option[_root_.scala.Boolean],
+    javaStringCheckUtf8: _root_.scala.Option[_root_.scala.Boolean],
+    optimizeFor: _root_.scala.Option[com.google.protobuf.descriptor.FileOptions.OptimizeMode],
+    goPackage: _root_.scala.Option[_root_.scala.Predef.String],
+    ccGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    javaGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    pyGenericServices: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    ccEnableArenas: _root_.scala.Option[_root_.scala.Boolean],
+    objcClassPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    csharpNamespace: _root_.scala.Option[_root_.scala.Predef.String],
+    swiftPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    phpClassPrefix: _root_.scala.Option[_root_.scala.Predef.String],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.FileOptions = _root_.com.google.protobuf.descriptor.FileOptions(
+    javaPackage,
+    javaOuterClassname,
+    javaMultipleFiles,
+    javaGenerateEqualsAndHash,
+    javaStringCheckUtf8,
+    optimizeFor,
+    goPackage,
+    ccGenericServices,
+    javaGenericServices,
+    pyGenericServices,
+    deprecated,
+    ccEnableArenas,
+    objcClassPrefix,
+    csharpNamespace,
+    swiftPrefix,
+    phpClassPrefix,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -301,10 +301,26 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
     final val SOURCE_FILE_FIELD_NUMBER = 2
     final val BEGIN_FIELD_NUMBER = 3
     final val END_FIELD_NUMBER = 4
+    def of(
+      path: _root_.scala.collection.Seq[_root_.scala.Int],
+      sourceFile: _root_.scala.Option[_root_.scala.Predef.String],
+      begin: _root_.scala.Option[_root_.scala.Int],
+      end: _root_.scala.Option[_root_.scala.Int]
+    ): _root_.com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation = _root_.com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation(
+      path,
+      sourceFile,
+      begin,
+      end
+    )
   }
   
   implicit class GeneratedCodeInfoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.GeneratedCodeInfo]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.GeneratedCodeInfo](_l) {
     def annotation: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation]] = field(_.annotation)((c_, f_) => c_.copy(annotation = f_))
   }
   final val ANNOTATION_FIELD_NUMBER = 1
+  def of(
+    annotation: _root_.scala.collection.Seq[com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation]
+  ): _root_.com.google.protobuf.descriptor.GeneratedCodeInfo = _root_.com.google.protobuf.descriptor.GeneratedCodeInfo(
+    annotation
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
@@ -256,4 +256,19 @@ object MessageOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   final val DEPRECATED_FIELD_NUMBER = 3
   final val MAP_ENTRY_FIELD_NUMBER = 7
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    messageSetWireFormat: _root_.scala.Option[_root_.scala.Boolean],
+    noStandardDescriptorAccessor: _root_.scala.Option[_root_.scala.Boolean],
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    mapEntry: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.MessageOptions = _root_.com.google.protobuf.descriptor.MessageOptions(
+    messageSetWireFormat,
+    noStandardDescriptorAccessor,
+    deprecated,
+    mapEntry,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -229,4 +229,19 @@ object MethodDescriptorProto extends scalapb.GeneratedMessageCompanion[com.googl
   final val OPTIONS_FIELD_NUMBER = 4
   final val CLIENT_STREAMING_FIELD_NUMBER = 5
   final val SERVER_STREAMING_FIELD_NUMBER = 6
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    inputType: _root_.scala.Option[_root_.scala.Predef.String],
+    outputType: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.MethodOptions],
+    clientStreaming: _root_.scala.Option[_root_.scala.Boolean],
+    serverStreaming: _root_.scala.Option[_root_.scala.Boolean]
+  ): _root_.com.google.protobuf.descriptor.MethodDescriptorProto = _root_.com.google.protobuf.descriptor.MethodDescriptorProto(
+    name,
+    inputType,
+    outputType,
+    options,
+    clientStreaming,
+    serverStreaming
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -216,4 +216,15 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
   final val DEPRECATED_FIELD_NUMBER = 33
   final val IDEMPOTENCY_LEVEL_FIELD_NUMBER = 34
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    idempotencyLevel: _root_.scala.Option[com.google.protobuf.descriptor.MethodOptions.IdempotencyLevel],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.MethodOptions = _root_.com.google.protobuf.descriptor.MethodOptions(
+    deprecated,
+    idempotencyLevel,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -129,4 +129,11 @@ object OneofDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   }
   final val NAME_FIELD_NUMBER = 1
   final val OPTIONS_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.OneofOptions]
+  ): _root_.com.google.protobuf.descriptor.OneofDescriptorProto = _root_.com.google.protobuf.descriptor.OneofDescriptorProto(
+    name,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
@@ -114,4 +114,11 @@ object OneofOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
     def uninterpretedOption: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption]] = field(_.uninterpretedOption)((c_, f_) => c_.copy(uninterpretedOption = f_))
   }
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.OneofOptions = _root_.com.google.protobuf.descriptor.OneofOptions(
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -155,4 +155,13 @@ object ServiceDescriptorProto extends scalapb.GeneratedMessageCompanion[com.goog
   final val NAME_FIELD_NUMBER = 1
   final val METHOD_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Option[_root_.scala.Predef.String],
+    method: _root_.scala.collection.Seq[com.google.protobuf.descriptor.MethodDescriptorProto],
+    options: _root_.scala.Option[com.google.protobuf.descriptor.ServiceOptions]
+  ): _root_.com.google.protobuf.descriptor.ServiceDescriptorProto = _root_.com.google.protobuf.descriptor.ServiceDescriptorProto(
+    name,
+    method,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -142,4 +142,13 @@ object ServiceOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   }
   final val DEPRECATED_FIELD_NUMBER = 33
   final val UNINTERPRETED_OPTION_FIELD_NUMBER = 999
+  def of(
+    deprecated: _root_.scala.Option[_root_.scala.Boolean],
+    uninterpretedOption: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption],
+    unknownFields: _root_.scalapb.UnknownFieldSet
+  ): _root_.com.google.protobuf.descriptor.ServiceOptions = _root_.com.google.protobuf.descriptor.ServiceOptions(
+    deprecated,
+    uninterpretedOption,
+    unknownFields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -448,10 +448,28 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
     final val LEADING_COMMENTS_FIELD_NUMBER = 3
     final val TRAILING_COMMENTS_FIELD_NUMBER = 4
     final val LEADING_DETACHED_COMMENTS_FIELD_NUMBER = 6
+    def of(
+      path: _root_.scala.collection.Seq[_root_.scala.Int],
+      span: _root_.scala.collection.Seq[_root_.scala.Int],
+      leadingComments: _root_.scala.Option[_root_.scala.Predef.String],
+      trailingComments: _root_.scala.Option[_root_.scala.Predef.String],
+      leadingDetachedComments: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+    ): _root_.com.google.protobuf.descriptor.SourceCodeInfo.Location = _root_.com.google.protobuf.descriptor.SourceCodeInfo.Location(
+      path,
+      span,
+      leadingComments,
+      trailingComments,
+      leadingDetachedComments
+    )
   }
   
   implicit class SourceCodeInfoLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.SourceCodeInfo]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.SourceCodeInfo](_l) {
     def location: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.descriptor.SourceCodeInfo.Location]] = field(_.location)((c_, f_) => c_.copy(location = f_))
   }
   final val LOCATION_FIELD_NUMBER = 1
+  def of(
+    location: _root_.scala.collection.Seq[com.google.protobuf.descriptor.SourceCodeInfo.Location]
+  ): _root_.com.google.protobuf.descriptor.SourceCodeInfo = _root_.com.google.protobuf.descriptor.SourceCodeInfo(
+    location
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -357,6 +357,13 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
     }
     final val NAME_PART_FIELD_NUMBER = 1
     final val IS_EXTENSION_FIELD_NUMBER = 2
+    def of(
+      namePart: _root_.scala.Predef.String,
+      isExtension: _root_.scala.Boolean
+    ): _root_.com.google.protobuf.descriptor.UninterpretedOption.NamePart = _root_.com.google.protobuf.descriptor.UninterpretedOption.NamePart(
+      namePart,
+      isExtension
+    )
   }
   
   implicit class UninterpretedOptionLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.descriptor.UninterpretedOption]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.descriptor.UninterpretedOption](_l) {
@@ -381,4 +388,21 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
   final val DOUBLE_VALUE_FIELD_NUMBER = 6
   final val STRING_VALUE_FIELD_NUMBER = 7
   final val AGGREGATE_VALUE_FIELD_NUMBER = 8
+  def of(
+    name: _root_.scala.collection.Seq[com.google.protobuf.descriptor.UninterpretedOption.NamePart],
+    identifierValue: _root_.scala.Option[_root_.scala.Predef.String],
+    positiveIntValue: _root_.scala.Option[_root_.scala.Long],
+    negativeIntValue: _root_.scala.Option[_root_.scala.Long],
+    doubleValue: _root_.scala.Option[_root_.scala.Double],
+    stringValue: _root_.scala.Option[_root_.com.google.protobuf.ByteString],
+    aggregateValue: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.descriptor.UninterpretedOption = _root_.com.google.protobuf.descriptor.UninterpretedOption(
+    name,
+    identifierValue,
+    positiveIntValue,
+    negativeIntValue,
+    doubleValue,
+    stringValue,
+    aggregateValue
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/duration/Duration.scala
@@ -200,4 +200,11 @@ object Duration extends scalapb.GeneratedMessageCompanion[com.google.protobuf.du
   }
   final val SECONDS_FIELD_NUMBER = 1
   final val NANOS_FIELD_NUMBER = 2
+  def of(
+    seconds: _root_.scala.Long,
+    nanos: _root_.scala.Int
+  ): _root_.com.google.protobuf.duration.Duration = _root_.com.google.protobuf.duration.Duration(
+    seconds,
+    nanos
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/empty/Empty.scala
@@ -62,4 +62,7 @@ object Empty extends scalapb.GeneratedMessageCompanion[com.google.protobuf.empty
   )
   implicit class EmptyLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.empty.Empty]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.empty.Empty](_l) {
   }
+  def of(
+  ): _root_.com.google.protobuf.empty.Empty = _root_.com.google.protobuf.empty.Empty(
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/field_mask/FieldMask.scala
@@ -301,4 +301,9 @@ object FieldMask extends scalapb.GeneratedMessageCompanion[com.google.protobuf.f
     def paths: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[_root_.scala.Predef.String]] = field(_.paths)((c_, f_) => c_.copy(paths = f_))
   }
   final val PATHS_FIELD_NUMBER = 1
+  def of(
+    paths: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.com.google.protobuf.field_mask.FieldMask = _root_.com.google.protobuf.field_mask.FieldMask(
+    paths
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/source_context/SourceContext.scala
@@ -108,4 +108,9 @@ object SourceContext extends scalapb.GeneratedMessageCompanion[com.google.protob
     def fileName: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.fileName)((c_, f_) => c_.copy(fileName = f_))
   }
   final val FILE_NAME_FIELD_NUMBER = 1
+  def of(
+    fileName: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.source_context.SourceContext = _root_.com.google.protobuf.source_context.SourceContext(
+    fileName
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
@@ -111,4 +111,9 @@ object ListValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.s
     def values: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[com.google.protobuf.struct.Value]] = field(_.values)((c_, f_) => c_.copy(values = f_))
   }
   final val VALUES_FIELD_NUMBER = 1
+  def of(
+    values: _root_.scala.collection.Seq[com.google.protobuf.struct.Value]
+  ): _root_.com.google.protobuf.struct.ListValue = _root_.com.google.protobuf.struct.ListValue(
+    values
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
@@ -243,6 +243,13 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
     final val VALUE_FIELD_NUMBER = 2
     implicit val keyValueMapper: _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)] =
       _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)](__m => (__m.key, __m.getValue))(__p => com.google.protobuf.struct.Struct.FieldsEntry(__p._1, Some(__p._2)))
+    def of(
+      key: _root_.scala.Predef.String,
+      value: _root_.scala.Option[com.google.protobuf.struct.Value]
+    ): _root_.com.google.protobuf.struct.Struct.FieldsEntry = _root_.com.google.protobuf.struct.Struct.FieldsEntry(
+      key,
+      value
+    )
   }
   
   implicit class StructLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, com.google.protobuf.struct.Struct]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, com.google.protobuf.struct.Struct](_l) {
@@ -251,4 +258,9 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
   final val FIELDS_FIELD_NUMBER = 1
   @transient
   private val _typemapper_fields: _root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)] = implicitly[_root_.scalapb.TypeMapper[com.google.protobuf.struct.Struct.FieldsEntry, (_root_.scala.Predef.String, com.google.protobuf.struct.Value)]]
+  def of(
+    fields: scala.collection.immutable.Map[_root_.scala.Predef.String, com.google.protobuf.struct.Value]
+  ): _root_.com.google.protobuf.struct.Struct = _root_.com.google.protobuf.struct.Struct(
+    fields
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/Value.scala
@@ -280,4 +280,9 @@ object Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.struc
   final val BOOL_VALUE_FIELD_NUMBER = 4
   final val STRUCT_VALUE_FIELD_NUMBER = 5
   final val LIST_VALUE_FIELD_NUMBER = 6
+  def of(
+    kind: com.google.protobuf.struct.Value.Kind
+  ): _root_.com.google.protobuf.struct.Value = _root_.com.google.protobuf.struct.Value(
+    kind
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/timestamp/Timestamp.scala
@@ -216,4 +216,11 @@ object Timestamp extends scalapb.GeneratedMessageCompanion[com.google.protobuf.t
   }
   final val SECONDS_FIELD_NUMBER = 1
   final val NANOS_FIELD_NUMBER = 2
+  def of(
+    seconds: _root_.scala.Long,
+    nanos: _root_.scala.Int
+  ): _root_.com.google.protobuf.timestamp.Timestamp = _root_.com.google.protobuf.timestamp.Timestamp(
+    seconds,
+    nanos
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Enum.scala
@@ -229,4 +229,17 @@ object Enum extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   final val OPTIONS_FIELD_NUMBER = 3
   final val SOURCE_CONTEXT_FIELD_NUMBER = 4
   final val SYNTAX_FIELD_NUMBER = 5
+  def of(
+    name: _root_.scala.Predef.String,
+    enumvalue: _root_.scala.collection.Seq[com.google.protobuf.`type`.EnumValue],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.`type`.Enum = _root_.com.google.protobuf.`type`.Enum(
+    name,
+    enumvalue,
+    options,
+    sourceContext,
+    syntax
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
@@ -169,4 +169,13 @@ object EnumValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`
   final val NAME_FIELD_NUMBER = 1
   final val NUMBER_FIELD_NUMBER = 2
   final val OPTIONS_FIELD_NUMBER = 3
+  def of(
+    name: _root_.scala.Predef.String,
+    number: _root_.scala.Int,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto]
+  ): _root_.com.google.protobuf.`type`.EnumValue = _root_.com.google.protobuf.`type`.EnumValue(
+    name,
+    number,
+    options
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -650,4 +650,27 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   final val OPTIONS_FIELD_NUMBER = 9
   final val JSON_NAME_FIELD_NUMBER = 10
   final val DEFAULT_VALUE_FIELD_NUMBER = 11
+  def of(
+    kind: com.google.protobuf.`type`.Field.Kind,
+    cardinality: com.google.protobuf.`type`.Field.Cardinality,
+    number: _root_.scala.Int,
+    name: _root_.scala.Predef.String,
+    typeUrl: _root_.scala.Predef.String,
+    oneofIndex: _root_.scala.Int,
+    packed: _root_.scala.Boolean,
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    jsonName: _root_.scala.Predef.String,
+    defaultValue: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.`type`.Field = _root_.com.google.protobuf.`type`.Field(
+    kind,
+    cardinality,
+    number,
+    name,
+    typeUrl,
+    oneofIndex,
+    packed,
+    options,
+    jsonName,
+    defaultValue
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
@@ -146,4 +146,11 @@ object OptionProto extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   }
   final val NAME_FIELD_NUMBER = 1
   final val VALUE_FIELD_NUMBER = 2
+  def of(
+    name: _root_.scala.Predef.String,
+    value: _root_.scala.Option[com.google.protobuf.any.Any]
+  ): _root_.com.google.protobuf.`type`.OptionProto = _root_.com.google.protobuf.`type`.OptionProto(
+    name,
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Type.scala
@@ -254,4 +254,19 @@ object Type extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   final val OPTIONS_FIELD_NUMBER = 4
   final val SOURCE_CONTEXT_FIELD_NUMBER = 5
   final val SYNTAX_FIELD_NUMBER = 6
+  def of(
+    name: _root_.scala.Predef.String,
+    fields: _root_.scala.collection.Seq[com.google.protobuf.`type`.Field],
+    oneofs: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    options: _root_.scala.collection.Seq[com.google.protobuf.`type`.OptionProto],
+    sourceContext: _root_.scala.Option[com.google.protobuf.source_context.SourceContext],
+    syntax: com.google.protobuf.`type`.Syntax
+  ): _root_.com.google.protobuf.`type`.Type = _root_.com.google.protobuf.`type`.Type(
+    name,
+    fields,
+    oneofs,
+    options,
+    sourceContext,
+    syntax
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BoolValue.scala
@@ -108,4 +108,9 @@ object BoolValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.w
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Boolean] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Boolean
+  ): _root_.com.google.protobuf.wrappers.BoolValue = _root_.com.google.protobuf.wrappers.BoolValue(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/BytesValue.scala
@@ -108,4 +108,9 @@ object BytesValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.com.google.protobuf.ByteString] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.com.google.protobuf.ByteString
+  ): _root_.com.google.protobuf.wrappers.BytesValue = _root_.com.google.protobuf.wrappers.BytesValue(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/DoubleValue.scala
@@ -108,4 +108,9 @@ object DoubleValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Double] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Double
+  ): _root_.com.google.protobuf.wrappers.DoubleValue = _root_.com.google.protobuf.wrappers.DoubleValue(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/FloatValue.scala
@@ -108,4 +108,9 @@ object FloatValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Float] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Float
+  ): _root_.com.google.protobuf.wrappers.FloatValue = _root_.com.google.protobuf.wrappers.FloatValue(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int32Value.scala
@@ -108,4 +108,9 @@ object Int32Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Int] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Int
+  ): _root_.com.google.protobuf.wrappers.Int32Value = _root_.com.google.protobuf.wrappers.Int32Value(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/Int64Value.scala
@@ -108,4 +108,9 @@ object Int64Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Long] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Long
+  ): _root_.com.google.protobuf.wrappers.Int64Value = _root_.com.google.protobuf.wrappers.Int64Value(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/StringValue.scala
@@ -108,4 +108,9 @@ object StringValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Predef.String
+  ): _root_.com.google.protobuf.wrappers.StringValue = _root_.com.google.protobuf.wrappers.StringValue(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt32Value.scala
@@ -108,4 +108,9 @@ object UInt32Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Int] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Int
+  ): _root_.com.google.protobuf.wrappers.UInt32Value = _root_.com.google.protobuf.wrappers.UInt32Value(
+    value
+  )
 }

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/wrappers/UInt64Value.scala
@@ -108,4 +108,9 @@ object UInt64Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf
     def value: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Long] = field(_.value)((c_, f_) => c_.copy(value = f_))
   }
   final val VALUE_FIELD_NUMBER = 1
+  def of(
+    value: _root_.scala.Long
+  ): _root_.com.google.protobuf.wrappers.UInt64Value = _root_.com.google.protobuf.wrappers.UInt64Value(
+    value
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumOptions.scala
@@ -150,4 +150,13 @@ object EnumOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.Enu
   final val EXTENDS_FIELD_NUMBER = 1
   final val COMPANION_EXTENDS_FIELD_NUMBER = 2
   final val TYPE_FIELD_NUMBER = 3
+  def of(
+    `extends`: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    companionExtends: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    `type`: _root_.scala.Option[_root_.scala.Predef.String]
+  ): _root_.scalapb.options.EnumOptions = _root_.scalapb.options.EnumOptions(
+    `extends`,
+    companionExtends,
+    `type`
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumValueOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/EnumValueOptions.scala
@@ -99,4 +99,9 @@ object EnumValueOptions extends scalapb.GeneratedMessageCompanion[scalapb.option
     def `extends`: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[_root_.scala.Predef.String]] = field(_.`extends`)((c_, f_) => c_.copy(`extends` = f_))
   }
   final val EXTENDS_FIELD_NUMBER = 1
+  def of(
+    `extends`: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.scalapb.options.EnumValueOptions = _root_.scalapb.options.EnumValueOptions(
+    `extends`
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/FieldOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/FieldOptions.scala
@@ -246,4 +246,21 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.Fi
   final val VALUE_TYPE_FIELD_NUMBER = 5
   final val ANNOTATIONS_FIELD_NUMBER = 6
   final val NO_BOX_FIELD_NUMBER = 30
+  def of(
+    `type`: _root_.scala.Option[_root_.scala.Predef.String],
+    scalaName: _root_.scala.Option[_root_.scala.Predef.String],
+    collectionType: _root_.scala.Option[_root_.scala.Predef.String],
+    keyType: _root_.scala.Option[_root_.scala.Predef.String],
+    valueType: _root_.scala.Option[_root_.scala.Predef.String],
+    annotations: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    noBox: _root_.scala.Option[_root_.scala.Boolean]
+  ): _root_.scalapb.options.FieldOptions = _root_.scalapb.options.FieldOptions(
+    `type`,
+    scalaName,
+    collectionType,
+    keyType,
+    valueType,
+    annotations,
+    noBox
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/MessageOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/MessageOptions.scala
@@ -200,4 +200,17 @@ object MessageOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
   final val ANNOTATIONS_FIELD_NUMBER = 3
   final val TYPE_FIELD_NUMBER = 4
   final val COMPANION_ANNOTATIONS_FIELD_NUMBER = 5
+  def of(
+    `extends`: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    companionExtends: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    annotations: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    `type`: _root_.scala.Option[_root_.scala.Predef.String],
+    companionAnnotations: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.scalapb.options.MessageOptions = _root_.scalapb.options.MessageOptions(
+    `extends`,
+    companionExtends,
+    annotations,
+    `type`,
+    companionAnnotations
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/OneofOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/OneofOptions.scala
@@ -99,4 +99,9 @@ object OneofOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.On
     def `extends`: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.collection.Seq[_root_.scala.Predef.String]] = field(_.`extends`)((c_, f_) => c_.copy(`extends` = f_))
   }
   final val EXTENDS_FIELD_NUMBER = 1
+  def of(
+    `extends`: _root_.scala.collection.Seq[_root_.scala.Predef.String]
+  ): _root_.scalapb.options.OneofOptions = _root_.scalapb.options.OneofOptions(
+    `extends`
+  )
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
@@ -485,4 +485,35 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
   final val LENSES_FIELD_NUMBER = 12
   final val RETAIN_SOURCE_CODE_INFO_FIELD_NUMBER = 13
   final val TEST_ONLY_NO_JAVA_CONVERSIONS_FIELD_NUMBER = 100001
+  def of(
+    packageName: _root_.scala.Option[_root_.scala.Predef.String],
+    flatPackage: _root_.scala.Option[_root_.scala.Boolean],
+    `import`: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    preamble: _root_.scala.collection.Seq[_root_.scala.Predef.String],
+    singleFile: _root_.scala.Option[_root_.scala.Boolean],
+    noPrimitiveWrappers: _root_.scala.Option[_root_.scala.Boolean],
+    primitiveWrappers: _root_.scala.Option[_root_.scala.Boolean],
+    collectionType: _root_.scala.Option[_root_.scala.Predef.String],
+    preserveUnknownFields: _root_.scala.Option[_root_.scala.Boolean],
+    objectName: _root_.scala.Option[_root_.scala.Predef.String],
+    scope: _root_.scala.Option[scalapb.options.ScalaPbOptions.OptionsScope],
+    lenses: _root_.scala.Option[_root_.scala.Boolean],
+    retainSourceCodeInfo: _root_.scala.Option[_root_.scala.Boolean],
+    testOnlyNoJavaConversions: _root_.scala.Option[_root_.scala.Boolean]
+  ): _root_.scalapb.options.ScalaPbOptions = _root_.scalapb.options.ScalaPbOptions(
+    packageName,
+    flatPackage,
+    `import`,
+    preamble,
+    singleFile,
+    noPrimitiveWrappers,
+    primitiveWrappers,
+    collectionType,
+    preserveUnknownFields,
+    objectName,
+    scope,
+    lenses,
+    retainSourceCodeInfo,
+    testOnlyNoJavaConversions
+  )
 }


### PR DESCRIPTION
I want this method because default arguments causes a bug. In other words, sometimes I want pass all arguments explicitly. WDYT?