### PR TITLE
support for services & methods comments (stubs & runtime inspection)

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -146,6 +146,9 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
 
     def descriptorName = "SERVICE"
 
+    def scalaDescriptorSource: String =
+      s"${self.getFile.fileDescriptorObjectName}.scalaDescriptor.services(${self.getIndex})"
+
     def sourcePath: Seq[Int] = Seq(FileDescriptorProto.SERVICE_FIELD_NUMBER, self.getIndex)
 
     def comment: Option[String] = {

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -1,11 +1,17 @@
 package scalapb.compiler
 
-import com.google.protobuf.DescriptorProtos.{DescriptorProto, FileDescriptorProto, SourceCodeInfo}
+import com.google.protobuf.DescriptorProtos.{
+  DescriptorProto,
+  EnumDescriptorProto,
+  FileDescriptorProto,
+  ServiceDescriptorProto,
+  SourceCodeInfo
+}
 import com.google.protobuf.Descriptors._
 import com.google.protobuf.WireFormat.FieldType
-
 import scalapb.options.compiler.Scalapb
 import scalapb.options.compiler.Scalapb._
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.IndexedSeq
 
@@ -108,6 +114,21 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
     def name: String = name0.asSymbol
 
     def descriptorName = s"METHOD_${NameUtils.toAllCaps(method.getName)}"
+
+    def sourcePath: Seq[Int] = {
+      method.getService.sourcePath ++ Seq(
+        ServiceDescriptorProto.METHOD_FIELD_NUMBER,
+        method.getIndex
+      )
+    }
+
+    def comment: Option[String] = {
+      method.getFile
+        .findLocationByPath(sourcePath)
+        .map(t => t.getLeadingComments + t.getTrailingComments)
+        .map(Helper.escapeComment)
+        .filter(_.nonEmpty)
+    }
   }
 
   implicit final class ServiceDescriptorPimp(self: ServiceDescriptor) {
@@ -124,6 +145,16 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
     def methods = self.getMethods.asScala.toIndexedSeq
 
     def descriptorName = "SERVICE"
+
+    def sourcePath: Seq[Int] = Seq(FileDescriptorProto.SERVICE_FIELD_NUMBER, self.getIndex)
+
+    def comment: Option[String] = {
+      self.getFile
+        .findLocationByPath(sourcePath)
+        .map(t => t.getLeadingComments + t.getTrailingComments)
+        .map(Helper.escapeComment)
+        .filter(_.nonEmpty)
+    }
   }
 
   implicit class FieldDescriptorPimp(val fd: FieldDescriptor) {
@@ -642,6 +673,23 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
 
     def companionExtends: Seq[String] =
       s"_root_.scalapb.GeneratedEnumCompanion[${nameSymbol}]" +: scalaOptions.getCompanionExtendsList.asScala
+
+    def sourcePath: Seq[Int] = {
+      if (enum.isTopLevel) Seq(FileDescriptorProto.ENUM_TYPE_FIELD_NUMBER, enum.getIndex)
+      else
+        enum.getContainingType.sourcePath ++ Seq(
+          DescriptorProto.ENUM_TYPE_FIELD_NUMBER,
+          enum.getIndex
+        )
+    }
+
+    def comment: Option[String] = {
+      enum.getFile
+        .findLocationByPath(sourcePath)
+        .map(t => t.getLeadingComments + t.getTrailingComments)
+        .map(Helper.escapeComment)
+        .filter(_.nonEmpty)
+    }
   }
 
   implicit class EnumValueDescriptorPimp(val enumValue: EnumValueDescriptor) {
@@ -657,6 +705,21 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
           e -> ("is" + allCapsToCamelCase(e.getName, true))
         }
       )(enumValue)
+    }
+
+    def sourcePath: Seq[Int] = {
+      enumValue.getType.sourcePath ++ Seq(
+        EnumDescriptorProto.VALUE_FIELD_NUMBER,
+        enumValue.getIndex
+      )
+    }
+
+    def comment: Option[String] = {
+      enumValue.getFile
+        .findLocationByPath(sourcePath)
+        .map(t => t.getLeadingComments + t.getTrailingComments)
+        .map(Helper.escapeComment)
+        .filter(_.nonEmpty)
     }
   }
 

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -2,6 +2,7 @@ package scalapb.compiler
 
 import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
+import scalapb.compiler.ProtobufGenerator.asScalaDocBlock
 
 import scala.collection.JavaConverters._
 
@@ -32,18 +33,17 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
     })
   }
 
-  private[this] def serviceTrait: PrinterEndo = {
-    val endos: PrinterEndo = { p =>
-      p.seq(service.methods.map(m => serviceMethodSignature(m)))
-    }
-
-    p =>
-      p.add(s"trait ${service.name} extends _root_.scalapb.grpc.AbstractService {")
-        .indent
-        .add(s"override def serviceCompanion = ${service.name}")
-        .call(endos)
-        .outdent
-        .add("}")
+  private[this] def serviceTrait: PrinterEndo = { p =>
+    p.call(generateScalaDoc(service))
+      .add(s"trait ${service.name} extends _root_.scalapb.grpc.AbstractService {")
+      .indent
+      .add(s"override def serviceCompanion = ${service.name}")
+      .print(service.methods) {
+        case (p, method) =>
+          p.call(generateScalaDoc(method)).add(serviceMethodSignature(method))
+      }
+      .outdent
+      .add("}")
   }
 
   private[this] def serviceTraitCompanion: PrinterEndo = { p =>
@@ -61,18 +61,17 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       .add("}")
   }
 
-  private[this] def blockingClientTrait: PrinterEndo = {
-    val endos: PrinterEndo = { p =>
-      p.seq(service.methods.filter(_.canBeBlocking).map(m => blockingMethodSignature(m)))
-    }
-
-    p =>
-      p.add(s"trait ${service.blockingClient} {")
-        .indent
-        .add(s"def serviceCompanion = ${service.name}")
-        .call(endos)
-        .outdent
-        .add("}")
+  private[this] def blockingClientTrait: PrinterEndo = { p =>
+    p.call(generateScalaDoc(service))
+      .add(s"trait ${service.blockingClient} {")
+      .indent
+      .add(s"def serviceCompanion = ${service.name}")
+      .print(service.methods.filter(_.canBeBlocking)) {
+        case (p, method) =>
+          p.call(generateScalaDoc(method)).add(blockingMethodSignature(method))
+      }
+      .outdent
+      .add("}")
   }
 
   private[this] val channel     = "_root_.io.grpc.Channel"
@@ -105,7 +104,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
          else Seq())
 
       val body = s"${clientCalls}.${methodName}(${args.mkString(", ")})"
-      p.add(sig).addIndented(body).add("}").newline
+      p.call(generateScalaDoc(m)).add(sig).addIndented(body).add("}").newline
     }
 
   private def stubImplementation(
@@ -278,5 +277,15 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       .newline
       .outdent
       .add("}")
+  }
+
+  def generateScalaDoc(service: ServiceDescriptor): PrinterEndo = { fp =>
+    val lines = asScalaDocBlock(service.comment.map(_.split('\n').toSeq).getOrElse(Seq.empty))
+    fp.add(lines: _*)
+  }
+
+  def generateScalaDoc(method: MethodDescriptor): PrinterEndo = { fp =>
+    val lines = asScalaDocBlock(method.comment.map(_.split('\n').toSeq).getOrElse(Seq.empty))
+    fp.add(lines: _*)
   }
 }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -57,6 +57,9 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       .add(
         s"def javaDescriptor: _root_.com.google.protobuf.Descriptors.ServiceDescriptor = ${service.getFile.fileDescriptorObjectFullName}.javaDescriptor.getServices().get(${service.getIndex})"
       )
+      .add(
+        s"def scalaDescriptor: _root_.scalapb.descriptors.ServiceDescriptor = ${service.scalaDescriptorSource}"
+      )
       .outdent
       .add("}")
   }

--- a/e2e/src/main/protobuf/comments.proto
+++ b/e2e/src/main/protobuf/comments.proto
@@ -28,3 +28,9 @@ message Foo {
     }
 };
 // and here
+
+// a commented service
+service CommentedService {
+    // a commented RPC
+    rpc CommentedRPC (Foo) returns (Foo) {}
+}

--- a/e2e/src/test/scala/CommentsSpec.scala
+++ b/e2e/src/test/scala/CommentsSpec.scala
@@ -1,3 +1,4 @@
+import com.trueaccord.proto.e2e.comments.CommentedServiceGrpc.CommentedService
 import com.trueaccord.proto.e2e.comments._
 import org.scalatest._
 
@@ -10,6 +11,8 @@ class CommentsSpec extends FlatSpec with MustMatchers {
     val enumLocation = Foo.Bar.scalaDescriptor.enums(0).location.get
     val enumXyzLocation = Foo.Bar.MyBarEnum.XYZ.scalaValueDescriptor.location.get
     val enumDefLocation = Foo.Bar.MyBarEnum.DEF.scalaValueDescriptor.location.get
+    val serviceLocation = CommentedService.scalaDescriptor.location.get
+    val methodLocation = CommentedService.scalaDescriptor.methods(0).location.get
 
     fooLocation.getLeadingComments must be(" This is the foo comment\n")
 
@@ -26,5 +29,10 @@ class CommentsSpec extends FlatSpec with MustMatchers {
     enumXyzLocation.getLeadingComments must be(" My enum value\n")
 
     enumDefLocation.getLeadingComments must be(" Def comment\n")
+
+    serviceLocation.getLeadingComments must be(" a commented service\n")
+
+    methodLocation.getLeadingComments must be(" a commented RPC\n")
+
   }
 }

--- a/e2e/src/test/scala/ScalaDescriptorSpec.scala
+++ b/e2e/src/test/scala/ScalaDescriptorSpec.scala
@@ -1,5 +1,6 @@
 import com.trueaccord.proto.e2e.one_of.OneofTest.SubMessage
 import com.trueaccord.proto.e2e.one_of.{OneOfProto, OneofTest}
+import com.trueaccord.proto.e2e.service.Service1Grpc.Service1
 import scalapb.descriptors._
 import org.scalatest._
 
@@ -51,5 +52,9 @@ class ScalaDescriptorSpec extends FlatSpec with MustMatchers with LoneElement wi
     xyzs.scalaName must be ("xyzs")
 
     OneofTest.XYZ.scalaDescriptor.fullName must be ("com.trueaccord.proto.e2e.OneofTest.XYZ")
+
+    Service1.scalaDescriptor.fullName must be("com.trueaccord.proto.e2e.Service1")
+    val method = Service1.scalaDescriptor.methods.find(_.name == "SealedUnary").get
+    method.fullName must be("com.trueaccord.proto.e2e.Service1.SealedUnary")
   }
 }

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -364,6 +364,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   
   object Type extends _root_.scalapb.GeneratedEnumCompanion[Type] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Type] = this
+    /** 0 is reserved for errors.
+      * Order is weird for historical reasons.
+      */
     @SerialVersionUID(0L)
     case object TYPE_DOUBLE extends Type {
       val value = 1
@@ -380,6 +383,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeFloat: _root_.scala.Boolean = true
     }
     
+    /** Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+      * negative values are likely.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT64 extends Type {
       val value = 3
@@ -396,6 +402,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeUint64: _root_.scala.Boolean = true
     }
     
+    /** Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+      * negative values are likely.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT32 extends Type {
       val value = 5
@@ -436,6 +445,11 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeString: _root_.scala.Boolean = true
     }
     
+    /** Tag-delimited aggregate.
+      * Group type is deprecated and not supported in proto3. However, Proto3
+      * implementations should still be able to parse the group wire format and
+      * treat group fields as unknown fields.
+      */
     @SerialVersionUID(0L)
     case object TYPE_GROUP extends Type {
       val value = 10
@@ -444,6 +458,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeGroup: _root_.scala.Boolean = true
     }
     
+    /** Length-delimited aggregate.
+      */
     @SerialVersionUID(0L)
     case object TYPE_MESSAGE extends Type {
       val value = 11
@@ -452,6 +468,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeMessage: _root_.scala.Boolean = true
     }
     
+    /** New in version 2.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BYTES extends Type {
       val value = 12
@@ -492,6 +510,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeSfixed64: _root_.scala.Boolean = true
     }
     
+    /** Uses ZigZag encoding.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT32 extends Type {
       val value = 17
@@ -500,6 +520,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeSint32: _root_.scala.Boolean = true
     }
     
+    /** Uses ZigZag encoding.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT64 extends Type {
       val value = 18
@@ -551,6 +573,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   
   object Label extends _root_.scalapb.GeneratedEnumCompanion[Label] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Label] = this
+    /** 0 is reserved for errors
+      */
     @SerialVersionUID(0L)
     case object LABEL_OPTIONAL extends Label {
       val value = 1

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -323,6 +323,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   
   object CType extends _root_.scalapb.GeneratedEnumCompanion[CType] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[CType] = this
+    /** Default mode.
+      */
     @SerialVersionUID(0L)
     case object STRING extends CType {
       val value = 0
@@ -375,6 +377,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   
   object JSType extends _root_.scalapb.GeneratedEnumCompanion[JSType] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[JSType] = this
+    /** Use the default type.
+      */
     @SerialVersionUID(0L)
     case object JS_NORMAL extends JSType {
       val value = 0
@@ -383,6 +387,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
       override def isJsNormal: _root_.scala.Boolean = true
     }
     
+    /** Use JavaScript strings.
+      */
     @SerialVersionUID(0L)
     case object JS_STRING extends JSType {
       val value = 1
@@ -391,6 +397,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
       override def isJsString: _root_.scala.Boolean = true
     }
     
+    /** Use JavaScript numbers.
+      */
     @SerialVersionUID(0L)
     case object JS_NUMBER extends JSType {
       val value = 2

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -540,6 +540,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   }
   lazy val defaultInstance = com.google.protobuf.descriptor.FileOptions(
   )
+  /** Generated classes can be optimized for speed or code size.
+    */
   sealed trait OptimizeMode extends _root_.scalapb.GeneratedEnum {
     type EnumType = OptimizeMode
     def isSpeed: _root_.scala.Boolean = false
@@ -550,6 +552,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   
   object OptimizeMode extends _root_.scalapb.GeneratedEnumCompanion[OptimizeMode] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[OptimizeMode] = this
+    /** Generate complete code for parsing, serialization,
+      */
     @SerialVersionUID(0L)
     case object SPEED extends OptimizeMode {
       val value = 1
@@ -558,6 +562,9 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
       override def isSpeed: _root_.scala.Boolean = true
     }
     
+    /** etc.
+      * Use ReflectionOps to implement these methods.
+      */
     @SerialVersionUID(0L)
     case object CODE_SIZE extends OptimizeMode {
       val value = 2
@@ -566,6 +573,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
       override def isCodeSize: _root_.scala.Boolean = true
     }
     
+    /** Generate code using MessageLite and the lite runtime.
+      */
     @SerialVersionUID(0L)
     case object LITE_RUNTIME extends OptimizeMode {
       val value = 3

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -172,6 +172,10 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
   }
   lazy val defaultInstance = com.google.protobuf.descriptor.MethodOptions(
   )
+  /** Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+    * or neither? HTTP based RPC implementation may choose GET verb for safe
+    * methods, and PUT verb for idempotent methods instead of the default POST.
+    */
   sealed trait IdempotencyLevel extends _root_.scalapb.GeneratedEnum {
     type EnumType = IdempotencyLevel
     def isIdempotencyUnknown: _root_.scala.Boolean = false
@@ -190,6 +194,8 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
       override def isIdempotencyUnknown: _root_.scala.Boolean = true
     }
     
+    /** implies idempotent
+      */
     @SerialVersionUID(0L)
     case object NO_SIDE_EFFECTS extends IdempotencyLevel {
       val value = 1
@@ -198,6 +204,8 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
       override def isNoSideEffects: _root_.scala.Boolean = true
     }
     
+    /** idempotent, but may have side effects
+      */
     @SerialVersionUID(0L)
     case object IDEMPOTENT extends IdempotencyLevel {
       val value = 2

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/NullValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/NullValue.scala
@@ -5,6 +5,11 @@
 
 package com.google.protobuf.struct
 
+/** `NullValue` is a singleton enumeration to represent the null value for the
+  * `Value` type union.
+  *
+  *  The JSON representation for `NullValue` is JSON `null`.
+  */
 sealed trait NullValue extends _root_.scalapb.GeneratedEnum {
   type EnumType = NullValue
   def isNullValue: _root_.scala.Boolean = false
@@ -13,6 +18,8 @@ sealed trait NullValue extends _root_.scalapb.GeneratedEnum {
 
 object NullValue extends _root_.scalapb.GeneratedEnumCompanion[NullValue] {
   implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[NullValue] = this
+  /** Null value.
+    */
   @SerialVersionUID(0L)
   case object NULL_VALUE extends NullValue {
     val value = 0

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -391,6 +391,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   }
   lazy val defaultInstance = com.google.protobuf.`type`.Field(
   )
+  /** Basic field types.
+    */
   sealed trait Kind extends _root_.scalapb.GeneratedEnum {
     type EnumType = Kind
     def isTypeUnknown: _root_.scala.Boolean = false
@@ -417,6 +419,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   
   object Kind extends _root_.scalapb.GeneratedEnumCompanion[Kind] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Kind] = this
+    /** Field type unknown.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UNKNOWN extends Kind {
       val value = 0
@@ -425,6 +429,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUnknown: _root_.scala.Boolean = true
     }
     
+    /** Field type double.
+      */
     @SerialVersionUID(0L)
     case object TYPE_DOUBLE extends Kind {
       val value = 1
@@ -433,6 +439,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeDouble: _root_.scala.Boolean = true
     }
     
+    /** Field type float.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FLOAT extends Kind {
       val value = 2
@@ -441,6 +449,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFloat: _root_.scala.Boolean = true
     }
     
+    /** Field type int64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT64 extends Kind {
       val value = 3
@@ -449,6 +459,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeInt64: _root_.scala.Boolean = true
     }
     
+    /** Field type uint64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UINT64 extends Kind {
       val value = 4
@@ -457,6 +469,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUint64: _root_.scala.Boolean = true
     }
     
+    /** Field type int32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT32 extends Kind {
       val value = 5
@@ -465,6 +479,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeInt32: _root_.scala.Boolean = true
     }
     
+    /** Field type fixed64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FIXED64 extends Kind {
       val value = 6
@@ -473,6 +489,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFixed64: _root_.scala.Boolean = true
     }
     
+    /** Field type fixed32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FIXED32 extends Kind {
       val value = 7
@@ -481,6 +499,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFixed32: _root_.scala.Boolean = true
     }
     
+    /** Field type bool.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BOOL extends Kind {
       val value = 8
@@ -489,6 +509,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeBool: _root_.scala.Boolean = true
     }
     
+    /** Field type string.
+      */
     @SerialVersionUID(0L)
     case object TYPE_STRING extends Kind {
       val value = 9
@@ -497,6 +519,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeString: _root_.scala.Boolean = true
     }
     
+    /** Field type group. Proto2 syntax only, and deprecated.
+      */
     @SerialVersionUID(0L)
     case object TYPE_GROUP extends Kind {
       val value = 10
@@ -505,6 +529,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeGroup: _root_.scala.Boolean = true
     }
     
+    /** Field type message.
+      */
     @SerialVersionUID(0L)
     case object TYPE_MESSAGE extends Kind {
       val value = 11
@@ -513,6 +539,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeMessage: _root_.scala.Boolean = true
     }
     
+    /** Field type bytes.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BYTES extends Kind {
       val value = 12
@@ -521,6 +549,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeBytes: _root_.scala.Boolean = true
     }
     
+    /** Field type uint32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UINT32 extends Kind {
       val value = 13
@@ -529,6 +559,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUint32: _root_.scala.Boolean = true
     }
     
+    /** Field type enum.
+      */
     @SerialVersionUID(0L)
     case object TYPE_ENUM extends Kind {
       val value = 14
@@ -537,6 +569,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeEnum: _root_.scala.Boolean = true
     }
     
+    /** Field type sfixed32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SFIXED32 extends Kind {
       val value = 15
@@ -545,6 +579,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSfixed32: _root_.scala.Boolean = true
     }
     
+    /** Field type sfixed64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SFIXED64 extends Kind {
       val value = 16
@@ -553,6 +589,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSfixed64: _root_.scala.Boolean = true
     }
     
+    /** Field type sint32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT32 extends Kind {
       val value = 17
@@ -561,6 +599,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSint32: _root_.scala.Boolean = true
     }
     
+    /** Field type sint64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT64 extends Kind {
       val value = 18
@@ -603,6 +643,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       com.google.protobuf.Field.Kind.forNumber(pbScalaSource.value)
     }
   }
+  /** Whether a field is optional, required, or repeated.
+    */
   sealed trait Cardinality extends _root_.scalapb.GeneratedEnum {
     type EnumType = Cardinality
     def isCardinalityUnknown: _root_.scala.Boolean = false
@@ -614,6 +656,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   
   object Cardinality extends _root_.scalapb.GeneratedEnumCompanion[Cardinality] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Cardinality] = this
+    /** For fields with unknown cardinality.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_UNKNOWN extends Cardinality {
       val value = 0
@@ -622,6 +666,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityUnknown: _root_.scala.Boolean = true
     }
     
+    /** For optional fields.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_OPTIONAL extends Cardinality {
       val value = 1
@@ -630,6 +676,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityOptional: _root_.scala.Boolean = true
     }
     
+    /** For required fields. Proto2 syntax only.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_REQUIRED extends Cardinality {
       val value = 2
@@ -638,6 +686,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityRequired: _root_.scala.Boolean = true
     }
     
+    /** For repeated fields.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_REPEATED extends Cardinality {
       val value = 3

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Syntax.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Syntax.scala
@@ -5,6 +5,8 @@
 
 package com.google.protobuf.`type`
 
+/** The syntax in which a protocol buffer element is defined.
+  */
 sealed trait Syntax extends _root_.scalapb.GeneratedEnum {
   type EnumType = Syntax
   def isSyntaxProto2: _root_.scala.Boolean = false
@@ -14,6 +16,8 @@ sealed trait Syntax extends _root_.scalapb.GeneratedEnum {
 
 object Syntax extends _root_.scalapb.GeneratedEnumCompanion[Syntax] {
   implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Syntax] = this
+  /** Syntax `proto2`.
+    */
   @SerialVersionUID(0L)
   case object SYNTAX_PROTO2 extends Syntax {
     val value = 0
@@ -22,6 +26,8 @@ object Syntax extends _root_.scalapb.GeneratedEnumCompanion[Syntax] {
     override def isSyntaxProto2: _root_.scala.Boolean = true
   }
   
+  /** Syntax `proto3`.
+    */
   @SerialVersionUID(0L)
   case object SYNTAX_PROTO3 extends Syntax {
     val value = 1

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -338,6 +338,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   
   object Type extends _root_.scalapb.GeneratedEnumCompanion[Type] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Type] = this
+    /** 0 is reserved for errors.
+      * Order is weird for historical reasons.
+      */
     @SerialVersionUID(0L)
     case object TYPE_DOUBLE extends Type {
       val value = 1
@@ -354,6 +357,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeFloat: _root_.scala.Boolean = true
     }
     
+    /** Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+      * negative values are likely.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT64 extends Type {
       val value = 3
@@ -370,6 +376,9 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeUint64: _root_.scala.Boolean = true
     }
     
+    /** Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+      * negative values are likely.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT32 extends Type {
       val value = 5
@@ -410,6 +419,11 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeString: _root_.scala.Boolean = true
     }
     
+    /** Tag-delimited aggregate.
+      * Group type is deprecated and not supported in proto3. However, Proto3
+      * implementations should still be able to parse the group wire format and
+      * treat group fields as unknown fields.
+      */
     @SerialVersionUID(0L)
     case object TYPE_GROUP extends Type {
       val value = 10
@@ -418,6 +432,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeGroup: _root_.scala.Boolean = true
     }
     
+    /** Length-delimited aggregate.
+      */
     @SerialVersionUID(0L)
     case object TYPE_MESSAGE extends Type {
       val value = 11
@@ -426,6 +442,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeMessage: _root_.scala.Boolean = true
     }
     
+    /** New in version 2.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BYTES extends Type {
       val value = 12
@@ -466,6 +484,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeSfixed64: _root_.scala.Boolean = true
     }
     
+    /** Uses ZigZag encoding.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT32 extends Type {
       val value = 17
@@ -474,6 +494,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
       override def isTypeSint32: _root_.scala.Boolean = true
     }
     
+    /** Uses ZigZag encoding.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT64 extends Type {
       val value = 18
@@ -520,6 +542,8 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   
   object Label extends _root_.scalapb.GeneratedEnumCompanion[Label] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Label] = this
+    /** 0 is reserved for errors
+      */
     @SerialVersionUID(0L)
     case object LABEL_OPTIONAL extends Label {
       val value = 1

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -302,6 +302,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   
   object CType extends _root_.scalapb.GeneratedEnumCompanion[CType] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[CType] = this
+    /** Default mode.
+      */
     @SerialVersionUID(0L)
     case object STRING extends CType {
       val value = 0
@@ -349,6 +351,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   
   object JSType extends _root_.scalapb.GeneratedEnumCompanion[JSType] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[JSType] = this
+    /** Use the default type.
+      */
     @SerialVersionUID(0L)
     case object JS_NORMAL extends JSType {
       val value = 0
@@ -357,6 +361,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
       override def isJsNormal: _root_.scala.Boolean = true
     }
     
+    /** Use JavaScript strings.
+      */
     @SerialVersionUID(0L)
     case object JS_STRING extends JSType {
       val value = 1
@@ -365,6 +371,8 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
       override def isJsString: _root_.scala.Boolean = true
     }
     
+    /** Use JavaScript numbers.
+      */
     @SerialVersionUID(0L)
     case object JS_NUMBER extends JSType {
       val value = 2

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -499,6 +499,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   }
   lazy val defaultInstance = com.google.protobuf.descriptor.FileOptions(
   )
+  /** Generated classes can be optimized for speed or code size.
+    */
   sealed trait OptimizeMode extends _root_.scalapb.GeneratedEnum {
     type EnumType = OptimizeMode
     def isSpeed: _root_.scala.Boolean = false
@@ -509,6 +511,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   
   object OptimizeMode extends _root_.scalapb.GeneratedEnumCompanion[OptimizeMode] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[OptimizeMode] = this
+    /** Generate complete code for parsing, serialization,
+      */
     @SerialVersionUID(0L)
     case object SPEED extends OptimizeMode {
       val value = 1
@@ -517,6 +521,9 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
       override def isSpeed: _root_.scala.Boolean = true
     }
     
+    /** etc.
+      * Use ReflectionOps to implement these methods.
+      */
     @SerialVersionUID(0L)
     case object CODE_SIZE extends OptimizeMode {
       val value = 2
@@ -525,6 +532,8 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
       override def isCodeSize: _root_.scala.Boolean = true
     }
     
+    /** Generate code using MessageLite and the lite runtime.
+      */
     @SerialVersionUID(0L)
     case object LITE_RUNTIME extends OptimizeMode {
       val value = 3

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -159,6 +159,10 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
   }
   lazy val defaultInstance = com.google.protobuf.descriptor.MethodOptions(
   )
+  /** Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+    * or neither? HTTP based RPC implementation may choose GET verb for safe
+    * methods, and PUT verb for idempotent methods instead of the default POST.
+    */
   sealed trait IdempotencyLevel extends _root_.scalapb.GeneratedEnum {
     type EnumType = IdempotencyLevel
     def isIdempotencyUnknown: _root_.scala.Boolean = false
@@ -177,6 +181,8 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
       override def isIdempotencyUnknown: _root_.scala.Boolean = true
     }
     
+    /** implies idempotent
+      */
     @SerialVersionUID(0L)
     case object NO_SIDE_EFFECTS extends IdempotencyLevel {
       val value = 1
@@ -185,6 +191,8 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
       override def isNoSideEffects: _root_.scala.Boolean = true
     }
     
+    /** idempotent, but may have side effects
+      */
     @SerialVersionUID(0L)
     case object IDEMPOTENT extends IdempotencyLevel {
       val value = 2

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/NullValue.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/struct/NullValue.scala
@@ -5,6 +5,11 @@
 
 package com.google.protobuf.struct
 
+/** `NullValue` is a singleton enumeration to represent the null value for the
+  * `Value` type union.
+  *
+  *  The JSON representation for `NullValue` is JSON `null`.
+  */
 sealed trait NullValue extends _root_.scalapb.GeneratedEnum {
   type EnumType = NullValue
   def isNullValue: _root_.scala.Boolean = false
@@ -13,6 +18,8 @@ sealed trait NullValue extends _root_.scalapb.GeneratedEnum {
 
 object NullValue extends _root_.scalapb.GeneratedEnumCompanion[NullValue] {
   implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[NullValue] = this
+  /** Null value.
+    */
   @SerialVersionUID(0L)
   case object NULL_VALUE extends NullValue {
     val value = 0

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -364,6 +364,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   }
   lazy val defaultInstance = com.google.protobuf.`type`.Field(
   )
+  /** Basic field types.
+    */
   sealed trait Kind extends _root_.scalapb.GeneratedEnum {
     type EnumType = Kind
     def isTypeUnknown: _root_.scala.Boolean = false
@@ -390,6 +392,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   
   object Kind extends _root_.scalapb.GeneratedEnumCompanion[Kind] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Kind] = this
+    /** Field type unknown.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UNKNOWN extends Kind {
       val value = 0
@@ -398,6 +402,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUnknown: _root_.scala.Boolean = true
     }
     
+    /** Field type double.
+      */
     @SerialVersionUID(0L)
     case object TYPE_DOUBLE extends Kind {
       val value = 1
@@ -406,6 +412,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeDouble: _root_.scala.Boolean = true
     }
     
+    /** Field type float.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FLOAT extends Kind {
       val value = 2
@@ -414,6 +422,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFloat: _root_.scala.Boolean = true
     }
     
+    /** Field type int64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT64 extends Kind {
       val value = 3
@@ -422,6 +432,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeInt64: _root_.scala.Boolean = true
     }
     
+    /** Field type uint64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UINT64 extends Kind {
       val value = 4
@@ -430,6 +442,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUint64: _root_.scala.Boolean = true
     }
     
+    /** Field type int32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_INT32 extends Kind {
       val value = 5
@@ -438,6 +452,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeInt32: _root_.scala.Boolean = true
     }
     
+    /** Field type fixed64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FIXED64 extends Kind {
       val value = 6
@@ -446,6 +462,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFixed64: _root_.scala.Boolean = true
     }
     
+    /** Field type fixed32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_FIXED32 extends Kind {
       val value = 7
@@ -454,6 +472,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeFixed32: _root_.scala.Boolean = true
     }
     
+    /** Field type bool.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BOOL extends Kind {
       val value = 8
@@ -462,6 +482,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeBool: _root_.scala.Boolean = true
     }
     
+    /** Field type string.
+      */
     @SerialVersionUID(0L)
     case object TYPE_STRING extends Kind {
       val value = 9
@@ -470,6 +492,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeString: _root_.scala.Boolean = true
     }
     
+    /** Field type group. Proto2 syntax only, and deprecated.
+      */
     @SerialVersionUID(0L)
     case object TYPE_GROUP extends Kind {
       val value = 10
@@ -478,6 +502,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeGroup: _root_.scala.Boolean = true
     }
     
+    /** Field type message.
+      */
     @SerialVersionUID(0L)
     case object TYPE_MESSAGE extends Kind {
       val value = 11
@@ -486,6 +512,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeMessage: _root_.scala.Boolean = true
     }
     
+    /** Field type bytes.
+      */
     @SerialVersionUID(0L)
     case object TYPE_BYTES extends Kind {
       val value = 12
@@ -494,6 +522,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeBytes: _root_.scala.Boolean = true
     }
     
+    /** Field type uint32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_UINT32 extends Kind {
       val value = 13
@@ -502,6 +532,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeUint32: _root_.scala.Boolean = true
     }
     
+    /** Field type enum.
+      */
     @SerialVersionUID(0L)
     case object TYPE_ENUM extends Kind {
       val value = 14
@@ -510,6 +542,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeEnum: _root_.scala.Boolean = true
     }
     
+    /** Field type sfixed32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SFIXED32 extends Kind {
       val value = 15
@@ -518,6 +552,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSfixed32: _root_.scala.Boolean = true
     }
     
+    /** Field type sfixed64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SFIXED64 extends Kind {
       val value = 16
@@ -526,6 +562,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSfixed64: _root_.scala.Boolean = true
     }
     
+    /** Field type sint32.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT32 extends Kind {
       val value = 17
@@ -534,6 +572,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isTypeSint32: _root_.scala.Boolean = true
     }
     
+    /** Field type sint64.
+      */
     @SerialVersionUID(0L)
     case object TYPE_SINT64 extends Kind {
       val value = 18
@@ -571,6 +611,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
     def javaDescriptor: _root_.com.google.protobuf.Descriptors.EnumDescriptor = com.google.protobuf.`type`.Field.javaDescriptor.getEnumTypes.get(0)
     def scalaDescriptor: _root_.scalapb.descriptors.EnumDescriptor = com.google.protobuf.`type`.Field.scalaDescriptor.enums(0)
   }
+  /** Whether a field is optional, required, or repeated.
+    */
   sealed trait Cardinality extends _root_.scalapb.GeneratedEnum {
     type EnumType = Cardinality
     def isCardinalityUnknown: _root_.scala.Boolean = false
@@ -582,6 +624,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   
   object Cardinality extends _root_.scalapb.GeneratedEnumCompanion[Cardinality] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Cardinality] = this
+    /** For fields with unknown cardinality.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_UNKNOWN extends Cardinality {
       val value = 0
@@ -590,6 +634,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityUnknown: _root_.scala.Boolean = true
     }
     
+    /** For optional fields.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_OPTIONAL extends Cardinality {
       val value = 1
@@ -598,6 +644,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityOptional: _root_.scala.Boolean = true
     }
     
+    /** For required fields. Proto2 syntax only.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_REQUIRED extends Cardinality {
       val value = 2
@@ -606,6 +654,8 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
       override def isCardinalityRequired: _root_.scala.Boolean = true
     }
     
+    /** For repeated fields.
+      */
     @SerialVersionUID(0L)
     case object CARDINALITY_REPEATED extends Cardinality {
       val value = 3

--- a/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Syntax.scala
+++ b/scalapb-runtime/non-jvm/src/main/scala/com/google/protobuf/type/Syntax.scala
@@ -5,6 +5,8 @@
 
 package com.google.protobuf.`type`
 
+/** The syntax in which a protocol buffer element is defined.
+  */
 sealed trait Syntax extends _root_.scalapb.GeneratedEnum {
   type EnumType = Syntax
   def isSyntaxProto2: _root_.scala.Boolean = false
@@ -14,6 +16,8 @@ sealed trait Syntax extends _root_.scalapb.GeneratedEnum {
 
 object Syntax extends _root_.scalapb.GeneratedEnumCompanion[Syntax] {
   implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[Syntax] = this
+  /** Syntax `proto2`.
+    */
   @SerialVersionUID(0L)
   case object SYNTAX_PROTO2 extends Syntax {
     val value = 0
@@ -22,6 +26,8 @@ object Syntax extends _root_.scalapb.GeneratedEnumCompanion[Syntax] {
     override def isSyntaxProto2: _root_.scala.Boolean = true
   }
   
+  /** Syntax `proto3`.
+    */
   @SerialVersionUID(0L)
   case object SYNTAX_PROTO3 extends Syntax {
     val value = 1

--- a/scalapb-runtime/shared/src/main/scala/scalapb/descriptors/SourceCodePath.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/descriptors/SourceCodePath.scala
@@ -21,4 +21,13 @@ object SourceCodePath {
   def get(fd: FieldDescriptor): Seq[Int] = {
     get(fd.containingMessage) ++ Seq(DescriptorProto.FIELD_FIELD_NUMBER, fd.index)
   }
+
+  def get(fd: ServiceDescriptor): Seq[Int] = {
+    Seq(FileDescriptorProto.SERVICE_FIELD_NUMBER, fd.index)
+  }
+
+  def get(fd: MethodDescriptor): Seq[Int] = {
+    get(fd.containingService) ++ Seq(ServiceDescriptorProto.METHOD_FIELD_NUMBER, fd.index)
+  }
+
 }

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalaPbOptions.scala
@@ -406,6 +406,8 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
   }
   lazy val defaultInstance = scalapb.options.ScalaPbOptions(
   )
+  /** Whether to apply the options only to this file, or for the entire package (and its subpackages)
+    */
   sealed trait OptionsScope extends _root_.scalapb.GeneratedEnum {
     type EnumType = OptionsScope
     def isFile: _root_.scala.Boolean = false
@@ -415,6 +417,8 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
   
   object OptionsScope extends _root_.scalapb.GeneratedEnumCompanion[OptionsScope] {
     implicit def enumCompanion: _root_.scalapb.GeneratedEnumCompanion[OptionsScope] = this
+    /** Apply the options for this file only (default)
+      */
     @SerialVersionUID(0L)
     case object FILE extends OptionsScope {
       val value = 0
@@ -423,6 +427,8 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
       override def isFile: _root_.scala.Boolean = true
     }
     
+    /** Apply the options for the entire package and its subpackages.
+      */
     @SerialVersionUID(0L)
     case object PACKAGE extends OptionsScope {
       val value = 1


### PR DESCRIPTION
Not sure how this can be tested?
* `./make_plugin_proto.sh` shows the impact on enum & enum values
* I verified that the gRPC stubs generated in `e2e` (that do contain comments on RPCs) were coming out as expected:
```scala
  trait Service1 extends _root_.scalapb.grpc.AbstractService {
    override def serviceCompanion = Service1
    /** Computes string length
      */
    def unaryStringLength(request: com.trueaccord.proto.e2e.service.Req1): scala.concurrent.Future[com.trueaccord.proto.e2e.service.Res1]
    // ...
  }
```
```scala
  trait Service1BlockingClient {
    def serviceCompanion = Service1
    /** Computes string length
      */
    def unaryStringLength(request: com.trueaccord.proto.e2e.service.Req1): scala.concurrent.Future[com.trueaccord.proto.e2e.service.Res1]
    // ...
  }
```