### PR TITLE
Fix generated code when package starts with build

### DIFF
--- a/e2e/build.sbt
+++ b/e2e/build.sbt
@@ -65,6 +65,7 @@ val commonSettings = Seq(
 lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
+    compileOrder := CompileOrder.JavaThenScala,
     PB.protoSources in Compile += (PB.externalIncludePath in Compile).value / "grpc" / "reflection",
     PB.targets in Compile := Seq(
       PB.gens.java -> (sourceManaged in Compile).value,

--- a/e2e/src/main/protobuf/build_prefix_test.proto
+++ b/e2e/src/main/protobuf/build_prefix_test.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+package build.test_package.anywhere;
+
+import "google/protobuf/descriptor.proto";
+
+
+option java_multiple_files = true;
+option java_outer_classname = "RemoteExecutionProto";
+option java_package = "build.bazel.remote.execution.v2";
+
+extend google.protobuf.MethodOptions {
+  Response my_option = 51234;
+}
+
+message ByteMessage {
+  bytes s = 1;
+}
+
+
+message Request {
+  bytes s = 1;
+}
+
+message Response {
+  string post = 2;
+}
+
+// a commented service
+service CommentedService {
+    // a commented RPC
+  rpc Execute(Request) returns (stream ByteMessage) {
+    option (my_option) = { post: "/v2/{instance_name=**}/actions:execute" };
+  }
+}
+


### PR DESCRIPTION
The build method name is included in generated code which collides when used with some of the google api's under the build package space.

Added a failing test case, and included build as a special case with the context fields that we should include `_root_` for with