### PR TITLE
Lens optional set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -298,7 +298,13 @@ lazy val lenses = crossProject(JSPlatform, JVMPlatform, NativePlatform).in(file(
           )
       }
     },
-    mimaPreviousArtifacts := Set("com.thesamet.scalapb" %% "lenses" % MimaPreviousVersion)
+    mimaPreviousArtifacts := Set("com.thesamet.scalapb" %% "lenses" % MimaPreviousVersion),
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      Seq(
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scalapb.lenses.Lens.setOptional")
+      )
+    }
   )
   .jsSettings(
     scalacOptions += {

--- a/lenses/shared/src/main/scala/scalapb/lenses/Lenses.scala
+++ b/lenses/shared/src/main/scala/scalapb/lenses/Lenses.scala
@@ -20,6 +20,14 @@ trait Lens[Container, A] extends Any {
   /** alias to set */
   def :=(a: A) = set(a)
 
+  /** Optional assignment.
+    *
+    * Given a `Some[A]`, assign the `Some`'s value to the field. Given `None`, the
+    * container is unchanged.
+    */
+  def setOptional(aOpt: Option[A]): Mutation[Container] =
+    c => aOpt.fold(c)(set(_)(c))
+
   /** Represent an update operator (like x.y += 1 ) */
   def modify(f: A => A): Mutation[Container] = c => set(f(get(c)))(c)
 

--- a/lenses/shared/src/test/scala/scalapb/lenses/SimpleTest.scala
+++ b/lenses/shared/src/test/scala/scalapb/lenses/SimpleTest.scala
@@ -116,6 +116,14 @@ object SimpleTest extends TestSuite {
       mosh.update(_.address := portland) ==> (mosh.copy(address = portland))
     }
 
+    "it should support an existing value for an optional set" - {
+      mosh.update(_.firstName setOptional Some("foo")) ==> mosh.copy(firstName = "foo")
+    }
+
+    "it should support a non-existing value for an optional set" - {
+      mosh.update(_.firstName setOptional None) ==> mosh
+    }
+
     "it should allow adding to a sequence" - {
       mosh.update(_.address.residents :+= josh) ==> (mosh.copy(
         address = mosh.address.copy(residents = mosh.address.residents :+ josh)


### PR DESCRIPTION
Give lenses a new method that takes an Option of the field type, and only set the field if the Option is nonEmpty