### PR TITLE
Add scalapb import to custom types example

### DIFF
--- a/docs/src/main/markdown/customizations.md
+++ b/docs/src/main/markdown/customizations.md
@@ -289,6 +289,8 @@ correctness. For example, instead of using a raw integer for time fields, you ca
 wrap them in a `Seconds` class.
 
 ```protobuf
+import "scalapb/scalapb.proto";
+
 message Connection {
   optional int32 timeout = 1 [(scalapb.field).type = "mydomain.Seconds"];
 }


### PR DESCRIPTION
Update the documentation to make explicit on Custom Type example the scalapb import.

I had a hard time debugging because I didn't know that this import was needed, and leading to weird exceptions.