### PR TITLE
Added schema descriptor to gRPC method

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -141,6 +141,9 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
         ""
       }
     }
+
+    def javaDescriptorSource: String =
+      s"${method.getService.javaDescriptorSource}.getMethods.get(${method.getIndex})"
   }
 
   implicit final class ServiceDescriptorPimp(self: ServiceDescriptor) {
@@ -160,6 +163,9 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
 
     def scalaDescriptorSource: String =
       s"${self.getFile.fileDescriptorObjectName}.scalaDescriptor.services(${self.getIndex})"
+
+    def javaDescriptorSource: String =
+      s"${self.getFile.fileDescriptorObjectFullName}.javaDescriptor.getServices.get(${self.getIndex})"
 
     def sourcePath: Seq[Int] = Seq(FileDescriptorProto.SERVICE_FIELD_NUMBER, self.getIndex)
 

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -163,6 +163,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       |    .setSampledToLocalTracing(true)
       |    .setRequestMarshaller(${marshaller(method.inputType)})
       |    .setResponseMarshaller(${marshaller(method.outputType)})
+      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${service.getFile.fileDescriptorObjectFullName}.javaDescriptor, "${service.getName}", "${method.getName}"))
       |    .build()
       |"""
     )

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -163,7 +163,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       |    .setSampledToLocalTracing(true)
       |    .setRequestMarshaller(${marshaller(method.inputType)})
       |    .setResponseMarshaller(${marshaller(method.outputType)})
-      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${service.getFile.fileDescriptorObjectFullName}.javaDescriptor, "${service.getName}", "${method.getName}"))
+      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${service.getFile.fileDescriptorObjectFullName}.javaDescriptor, ${service.javaDescriptorSource}, ${method.javaDescriptorSource}))
       |    .build()
       |"""
     )

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -163,7 +163,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       |    .setSampledToLocalTracing(true)
       |    .setRequestMarshaller(${marshaller(method.inputType)})
       |    .setResponseMarshaller(${marshaller(method.outputType)})
-      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${service.getFile.fileDescriptorObjectFullName}.javaDescriptor, ${service.javaDescriptorSource}, ${method.javaDescriptorSource}))
+      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${method.javaDescriptorSource}))
       |    .build()
       |"""
     )

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -163,7 +163,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       |    .setSampledToLocalTracing(true)
       |    .setRequestMarshaller(${marshaller(method.inputType)})
       |    .setResponseMarshaller(${marshaller(method.outputType)})
-      |    .setSchemaDescriptor(new _root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier(${method.javaDescriptorSource}))
+      |    .setSchemaDescriptor(_root_.scalapb.grpc.ConcreteProtoMethodDescriptorSupplier.fromMethodDescriptor(${method.javaDescriptorSource}))
       |    .build()
       |"""
     )

--- a/e2e/src/main/protobuf/service.proto
+++ b/e2e/src/main/protobuf/service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package com.thesamet.proto.e2e;
 
 import "scalapb/scalapb.proto";
+import "google/protobuf/descriptor.proto";
 
 message Req1 {
   string request = 1;
@@ -45,9 +46,16 @@ message SealedResponse {
     }
 }
 
+extend google.protobuf.MethodOptions {
+    string custom_option = 50001;
+}
+
 service Service1 {
   // Computes string length
   rpc UnaryStringLength(Req1) returns (Res1) {}
+
+  // A custom option in method descriptor
+  rpc CustomOption(Req5) returns (Res5) { option (custom_option) = "custom_value"; }
 
   // Returns the count of messages received from the client.
   rpc ClientStreamingCount(stream Req2) returns (Res2) {}

--- a/e2e/src/main/scala/com/thesamet/pb/Service1Interceptor.scala
+++ b/e2e/src/main/scala/com/thesamet/pb/Service1Interceptor.scala
@@ -1,0 +1,26 @@
+package com.thesamet.pb
+
+import com.thesamet.proto.e2e.Service
+import io.grpc.protobuf.ProtoMethodDescriptorSupplier
+import io.grpc.{Context, Contexts, Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
+
+class Service1Interceptor extends ServerInterceptor {
+  override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT],
+      headers: Metadata,
+      next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
+    val schemaDescriptor =
+      call.getMethodDescriptor.getSchemaDescriptor.asInstanceOf[ProtoMethodDescriptorSupplier]
+
+    val value = for {
+      methodDescriptor <- Option(schemaDescriptor.getMethodDescriptor)
+      options <- Option(methodDescriptor.getOptions)
+    } yield options.getExtension(Service.customOption)
+
+    val newCtx = Context.current().withValue[String](Service1Interceptor.contextKey, value.getOrElse(""))
+    Contexts.interceptCall(newCtx, call, headers, next)
+  }
+}
+
+object Service1Interceptor {
+  val contextKey = Context.key[String]("CUSTOM_OPTION")
+}

--- a/e2e/src/main/scala/com/thesamet/pb/Service1JavaImpl.scala
+++ b/e2e/src/main/scala/com/thesamet/pb/Service1JavaImpl.scala
@@ -14,6 +14,17 @@ class Service1JavaImpl extends Service1ImplBase{
     observer.onCompleted()
   }
 
+  override def customOption(request: Req5, observer: StreamObserver[Res5]): Unit = {
+    Service1Interceptor.contextKey.get() match {
+      case "custom_value" =>
+        val res = Res5.newBuilder.build()
+        observer.onNext(res)
+        observer.onCompleted()
+      case _ =>
+        observer.onError(new RuntimeException("error"))
+    }
+  }
+
   override def clientStreamingCount(observer: StreamObserver[Res2]) =
     new StreamObserver[Req2] {
       private[this] val counter = new AtomicInteger()

--- a/e2e/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
+++ b/e2e/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
@@ -14,6 +14,13 @@ class Service1ScalaImpl extends Service1 {
   override def unaryStringLength(request: Req1): Future[Res1] =
     Future.successful(Res1(length = request.request.length))
 
+  override def customOption(request: Req5): Future[Res5] = {
+    Service1Interceptor.contextKey.get() match {
+      case "custom_value" => Future.successful(Res5())
+      case _ => Future.failed(new RuntimeException("error"))
+    }
+  }
+
   override def clientStreamingCount(observer: StreamObserver[Res2]) =
     new StreamObserver[Req2] {
       private[this] val counter = new AtomicInteger()

--- a/e2e/src/test/scala/GrpcServiceJavaServerSpec.scala
+++ b/e2e/src/test/scala/GrpcServiceJavaServerSpec.scala
@@ -25,6 +25,13 @@ class GrpcServiceJavaServerSpec extends GrpcServiceSpecBase {
       }
     }
 
+    it("customOption") {
+      withJavaServer { channel =>
+        val client = Service1GrpcScala.blockingStub(channel)
+        client.customOption(Req5()) must be(Res5())
+      }
+    }
+
     it("clientStreamingCount") {
       withJavaServer { channel =>
         val client = Service1GrpcScala.stub(channel)

--- a/e2e/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -96,6 +96,13 @@ class GrpcServiceScalaServerSpec extends GrpcServiceSpecBase {
         }
       }
 
+      it("customOption") {
+        withScalaServer { channel =>
+          val client = Service1GrpcScala.blockingStub(channel)
+          client.customOption(Req5()) must be(Res5())
+        }
+      }
+
       it("clientStreamingCount") {
         withScalaServer { channel =>
           val client = Service1GrpcScala.stub(channel)

--- a/e2e/src/test/scala/GrpcServiceSpecBase.scala
+++ b/e2e/src/test/scala/GrpcServiceSpecBase.scala
@@ -1,7 +1,6 @@
 import java.util.concurrent.TimeUnit
 
-import com.thesamet.pb.Service1JavaImpl
-import com.thesamet.pb.Service1ScalaImpl
+import com.thesamet.pb.{Service1Interceptor, Service1JavaImpl, Service1ScalaImpl}
 import com.thesamet.proto.e2e.service.{Service1Grpc => Service1GrpcScala}
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder, NettyServerBuilder}
 import io.grpc.protobuf.services.ProtoReflectionService
@@ -19,12 +18,14 @@ abstract class GrpcServiceSpecBase extends FunSpec with MustMatchers {
       _.addService(ProtoReflectionService.newInstance())
        .addService(
          Service1GrpcScala.bindService(new Service1ScalaImpl, singleThreadExecutionContext)
-       ).build()
+       )
+       .intercept(new Service1Interceptor)
+       .build()
     )(f)
   }
 
   protected[this] final def withJavaServer[A](f: ManagedChannel => A): A = {
-    withServer(_.addService(new Service1JavaImpl).build())(f)
+    withServer(_.addService(new Service1JavaImpl).intercept(new Service1Interceptor).build())(f)
   }
 
   private[this] def withServer[A](createServer: NettyServerBuilder => Server)(f: ManagedChannel => A): A = {

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
@@ -1,0 +1,15 @@
+package scalapb.grpc
+
+import com.google.protobuf.Descriptors
+import io.grpc.protobuf.{ProtoMethodDescriptorSupplier, ProtoServiceDescriptorSupplier}
+
+class ConcreteProtoMethodDescriptorSupplier(
+    fileDescriptor: Descriptors.FileDescriptor,
+    serviceName: String,
+    methodName: String) extends ProtoMethodDescriptorSupplier with ProtoServiceDescriptorSupplier {
+  override def getMethodDescriptor: Descriptors.MethodDescriptor = getServiceDescriptor.findMethodByName(methodName)
+
+  override def getServiceDescriptor: Descriptors.ServiceDescriptor = getFileDescriptor.findServiceByName(serviceName)
+
+  override def getFileDescriptor: Descriptors.FileDescriptor = fileDescriptor
+}

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
@@ -11,3 +11,10 @@ class ConcreteProtoMethodDescriptorSupplier(
   override def getServiceDescriptor: Descriptors.ServiceDescriptor = methodDescriptor.getService
   override def getFileDescriptor: Descriptors.FileDescriptor       = getServiceDescriptor.getFile
 }
+
+object ConcreteProtoMethodDescriptorSupplier {
+  def fromMethodDescriptor(
+      methodDescriptor: Descriptors.MethodDescriptor
+  ): ConcreteProtoMethodDescriptorSupplier =
+    new ConcreteProtoMethodDescriptorSupplier(methodDescriptor)
+}

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
@@ -5,15 +5,11 @@ import io.grpc.protobuf.{ProtoMethodDescriptorSupplier, ProtoServiceDescriptorSu
 
 class ConcreteProtoMethodDescriptorSupplier(
     fileDescriptor: Descriptors.FileDescriptor,
-    serviceName: String,
-    methodName: String
+    serviceDescriptor: Descriptors.ServiceDescriptor,
+    methodDescriptor: Descriptors.MethodDescriptor
 ) extends ProtoMethodDescriptorSupplier
     with ProtoServiceDescriptorSupplier {
-  override def getMethodDescriptor: Descriptors.MethodDescriptor =
-    getServiceDescriptor.findMethodByName(methodName)
-
-  override def getServiceDescriptor: Descriptors.ServiceDescriptor =
-    getFileDescriptor.findServiceByName(serviceName)
-
-  override def getFileDescriptor: Descriptors.FileDescriptor = fileDescriptor
+  override def getMethodDescriptor: Descriptors.MethodDescriptor   = methodDescriptor
+  override def getServiceDescriptor: Descriptors.ServiceDescriptor = serviceDescriptor
+  override def getFileDescriptor: Descriptors.FileDescriptor       = fileDescriptor
 }

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
@@ -4,12 +4,10 @@ import com.google.protobuf.Descriptors
 import io.grpc.protobuf.{ProtoMethodDescriptorSupplier, ProtoServiceDescriptorSupplier}
 
 class ConcreteProtoMethodDescriptorSupplier(
-    fileDescriptor: Descriptors.FileDescriptor,
-    serviceDescriptor: Descriptors.ServiceDescriptor,
     methodDescriptor: Descriptors.MethodDescriptor
 ) extends ProtoMethodDescriptorSupplier
     with ProtoServiceDescriptorSupplier {
   override def getMethodDescriptor: Descriptors.MethodDescriptor   = methodDescriptor
-  override def getServiceDescriptor: Descriptors.ServiceDescriptor = serviceDescriptor
-  override def getFileDescriptor: Descriptors.FileDescriptor       = fileDescriptor
+  override def getServiceDescriptor: Descriptors.ServiceDescriptor = methodDescriptor.getService
+  override def getFileDescriptor: Descriptors.FileDescriptor       = getServiceDescriptor.getFile
 }

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ConcreteProtoMethodDescriptorSupplier.scala
@@ -6,10 +6,14 @@ import io.grpc.protobuf.{ProtoMethodDescriptorSupplier, ProtoServiceDescriptorSu
 class ConcreteProtoMethodDescriptorSupplier(
     fileDescriptor: Descriptors.FileDescriptor,
     serviceName: String,
-    methodName: String) extends ProtoMethodDescriptorSupplier with ProtoServiceDescriptorSupplier {
-  override def getMethodDescriptor: Descriptors.MethodDescriptor = getServiceDescriptor.findMethodByName(methodName)
+    methodName: String
+) extends ProtoMethodDescriptorSupplier
+    with ProtoServiceDescriptorSupplier {
+  override def getMethodDescriptor: Descriptors.MethodDescriptor =
+    getServiceDescriptor.findMethodByName(methodName)
 
-  override def getServiceDescriptor: Descriptors.ServiceDescriptor = getFileDescriptor.findServiceByName(serviceName)
+  override def getServiceDescriptor: Descriptors.ServiceDescriptor =
+    getFileDescriptor.findServiceByName(serviceName)
 
   override def getFileDescriptor: Descriptors.FileDescriptor = fileDescriptor
 }


### PR DESCRIPTION
Currently `ServerCall#getSchemaDescriptor` returns null.
Therefore, it is not possible to access custom option definitions.
Now `MethodDescriptor` provides `SchemaDescriptor`, i have access to custom options via extensions.
And I added the corresponding E2E test.