### PR TITLE
Fix -Ybreak-cycles in ShemaGenerators.scala

### DIFF
--- a/proptest/src/test/scala/SchemaGenerators.scala
+++ b/proptest/src/test/scala/SchemaGenerators.scala
@@ -246,7 +246,7 @@ object SchemaGenerators {
       else Seq.empty
 
     s.processArgumentString(
-      s"""-cp "${classPath.mkString(":")}" ${maybeBreakCycles} -d "$rootDir""""
+      s"""-cp "${classPath.mkString(":")}" ${maybeBreakCycles.mkString(" ")} -d "$rootDir""""
     )
 
     val g   = new Global(s)


### PR DESCRIPTION
Trying to run these tests locally fails on `++2.12.8` because the `-Ybreak-cycles` flag wasn't included (See https://github.com/scalapb/ScalaPB/issues/384). The interpolation was including the Seq wrapper in the interpolated string i.e. `-cp blah:blah:blah Seq(-Ybreak-cycles) -d blah`, which obviously doesn't work.

Not sure if this is the correct solution, but the previous code was clearly wrong