### PR TITLE
Fix typo

### DIFF
--- a/docs/src/main/markdown/generated-code.md
+++ b/docs/src/main/markdown/generated-code.md
@@ -178,16 +178,16 @@ Using `update()` is especially fun with repeated fields:
 ```scala
 val p = Person().update(
   // Override the addresses
-  _.addressses := newListOfAddress,
+  _.addresses := newListOfAddress,
 
   // Add one address:
-  _.addressses :+= address1,
+  _.addresses :+= address1,
 
   // Add a list of addresses:
   _.addresses :++= Seq(address1, address2),
 
   // Modify an address in the list by index!
-  _.addressses(1).street := "Townsend St.",
+  _.addresses(1).street := "Townsend St.",
 
   // Modify all addresses:
   _.addresses.foreach(_.city := "San Francisco"),


### PR DESCRIPTION
I thought about adding the address message definition somewhere too, maybe to consider?

```
message Address {
  optional string street = 1;
  optional string city = 2;
}
```