### PR TITLE
Add helperMethod option to disable generation of withX and clearX

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -17,7 +17,8 @@ case class GeneratorParams(
     singleLineToProtoString: Boolean = false,
     asciiFormatToString: Boolean = false,
     lenses: Boolean = true,
-    retainSourceCodeInfo: Boolean = false
+    retainSourceCodeInfo: Boolean = false,
+    helperMethod: Boolean = true
 )
 
 // Exceptions that are caught and passed upstreams as errors.
@@ -1875,6 +1876,8 @@ object ProtobufGenerator {
           Right(params.copy(lenses = false))
         case (Right(params), "retain_source_code_info") =>
           Right(params.copy(retainSourceCodeInfo = true))
+        case (Right(params), "disable_helper_method") =>
+          Right(params.copy(helperMethod = false))
         case (Right(params), p) => Left(s"Unrecognized parameter: '$p'")
         case (x, _)             => x
       }

--- a/compiler-plugin/src/main/scala/scalapb/package.scala
+++ b/compiler-plugin/src/main/scala/scalapb/package.scala
@@ -19,6 +19,8 @@ package object scalapb {
     case object Lenses extends GeneratorOption
 
     case object RetainSourceCodeInfo extends GeneratorOption
+
+    case object HelperMethod extends GeneratorOption
   }
 
   def gen(options: Set[GeneratorOption]): (JvmGenerator, Seq[String]) =
@@ -31,7 +33,8 @@ package object scalapb {
         "single_line_to_proto_string" -> options(SingleLineToProtoString),
         "ascii_format_to_string"      -> options(AsciiFormatToString),
         "no_lenses"                   -> !options(Lenses),
-        "retain_source_code_info"     -> options(RetainSourceCodeInfo)
+        "retain_source_code_info"     -> options(RetainSourceCodeInfo),
+        "disable_helper_method"       -> !options(HelperMethod)
       ).collect { case (name, v) if v => name }
     )
 
@@ -41,7 +44,8 @@ package object scalapb {
       grpc: Boolean = true,
       singleLineToProtoString: Boolean = false,
       asciiFormatToString: Boolean = false,
-      lenses: Boolean = true
+      lenses: Boolean = true,
+      helperMethod: Boolean = true
   ): (JvmGenerator, Seq[String]) = {
     val optionsBuilder = Set.newBuilder[GeneratorOption]
     if (flatPackage) {
@@ -61,6 +65,9 @@ package object scalapb {
     }
     if (lenses) {
       optionsBuilder += Lenses
+    }
+    if (helperMethod) {
+      optionsBuilder += HelperMethod
     }
     gen(optionsBuilder.result())
   }


### PR DESCRIPTION
## What

This PR add `helperMethod` option to allow disable generation of withX and clearX method in message.

## Why

I have a large message, which contain around 200 fields, after scalapb generate scala source file, I use Scala 2.11 compile the generated scala source file to java class file. But the compiled java class file overflow [constant pool](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html), when I try to execute the java class file, it throws `ClassFormatError`.

```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.ClassFormatError: Invalid this class index 48204 in constant pool in class file RichEvent
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
    at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)
```

## Down to the rabbit hole

I use `hexdump` to decode my java class file because disassembler do not accept a invalid format class file

```
0000000 ca fe ba be 00 00 00 34 00 03 01 00 27 63 6f 6d
0000010 2f 74 75 62 69 74 76 2f 72 70 63 2f 61 6e 61 6c
```

The constant pool size is `00 03`.

If I remove some fields from my large protobufs message, the class file become valid(executable), the hexdump is

```
0000000 ca fe ba be 00 00 00 34 ff fc 01 00 27 63 6f 6d
0000010 2f 74 75 62 69 74 76 2f 72 70 63 2f 61 6e 61 6c
```

The constant pool size is `ff fc`.

It looks like because the protobufs message is too large, result in scala have too many variables and methods, which result in constant pool overflow and generate an invalid java class file.

## Solution

It might be a Scala compiler issue since I haven't exceed max method count in a single class, but I can't find corresponding issue with Google. A simpler solution is, since the scalapb generated withX and clearX method are replaceable, add an option to disable generate these method can fix this issue.

After disable generate withX and clearX methods, the hexdump is

```
0000000 ca fe ba be 00 00 00 34 1b ff 01 00 27 63 6f 6d
0000010 2f 74 75 62 69 74 76 2f 72 70 63 2f 61 6e 61 6c
```

The constant pool reduce to `1b ff`, I have plenty of room to growth  😄 