### PR TITLE
support custom service options in protoc-gen-scala

### DIFF
--- a/e2e/src/main/protobuf/service.proto
+++ b/e2e/src/main/protobuf/service.proto
@@ -51,7 +51,13 @@ extend google.protobuf.MethodOptions {
     string custom_option = 50001;
 }
 
+extend google.protobuf.ServiceOptions {
+    string custom_service_option = 50002;
+}
+
 service Service1 {
+  option (custom_service_option) = "custom_service_value";
+  
   // Computes string length
   rpc UnaryStringLength(Req1) returns (Res1) {}
 


### PR DESCRIPTION
protoc-gen-scala currently fails on services with custom options like this:

```
--scala_out: java.lang.RuntimeException: Generated message class "com.google.protobuf.DescriptorProtos$ServiceOptions" missing method "getDeprecated".
```

Looks like that's because `make_reflect_config.sh` didn't exercise that class in the e2e protos.

Adding a custom service option in e2e/src/main/protobuf/service.proto for this.