### PR TITLE
Deprecate FlatPackage as a GeneratorOption.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,11 @@ lazy val grpcRuntimeJVM2_12 = grpcRuntime.jvm(Scala212)
 lazy val compilerPlugin = (projectMatrix in file("compiler-plugin"))
   .settings(commonSettings)
   .settings(
+    scalacOptions ++= (if (!isDotty.value)
+                         Seq(
+                           "-P:silencer:globalFilters=object FlatPackage in object GeneratorOption is deprecated"
+                         )
+                       else Nil),
     libraryDependencies ++= Seq(
       protocGen.withDottyCompat(scalaVersion.value),
       "com.google.protobuf" % "protobuf-java" % protobufCompilerVersion % "protobuf",

--- a/compiler-plugin/src/main/scala/scalapb/GeneratorOption.scala
+++ b/compiler-plugin/src/main/scala/scalapb/GeneratorOption.scala
@@ -3,6 +3,7 @@ package scalapb
 sealed trait GeneratorOption extends Product with Serializable
 
 object GeneratorOption {
+  @deprecated("Use package-scoped option instead. See https://scalapb.github.io/customizations.html#package-scoped-options.", "0.11")
   case object FlatPackage extends GeneratorOption {
     override def toString = "flat_package"
   }


### PR DESCRIPTION
This will trigger on imported files as well, which will break if a related runtime was not compiled with this option enabled.
Since this is now supported as a package-level option, users can simply move to use that instead for compatibility.