### PR TITLE
remove Product from type inferred across GeneratedMessage

### DIFF
--- a/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -69,7 +69,7 @@ trait GeneratedOneof extends Any with Product with Serializable {
 
 trait GeneratedOneofCompanion
 
-trait GeneratedMessage extends Any with Serializable {
+trait GeneratedMessage extends Any with Product with Serializable {
 
   /** Serializes the message into the given coded output stream */
   def writeTo(output: CodedOutputStream): Unit


### PR DESCRIPTION
Similar to https://github.com/scalapb/ScalaPB/pull/59
See https://typelevel.org/blog/2018/05/09/product-with-serializable.html

Attempt at silencing [wartremover:Product](https://www.wartremover.org/doc/warts.html) when instantiating a `Seq` of `GeneratedMessage`s:
```
[wartremover:Product] Inferred type containing Product: Product with scalapb.GeneratedMessage with tv.teads.domains.commons.ScalaPBValidator[_ >: tv.teads.domains.account.events.RolesRevokedEvent with tv.teads.domains.account.events.AccountDeletedEvent <: Product with scalapb.GeneratedMessage with tv.teads.domains.commons.ScalaPBValidator[_ >: tv.teads.domains.account.events.RolesRevokedEvent with tv.teads.domains.account.events.AccountDeletedEvent <: Product with scalapb.GeneratedMessage]{def companion: java.io.Serializable}]{def companion: scalapb.GeneratedMessageCompanion[_ >: tv.teads.domains.account.events.RolesRevokedEvent with tv.teads.domains.account.events.AccountDeletedEvent <: Product with scalapb.GeneratedMessage] with java.io.Serializable}
[error]         Seq(
[error]         ^
[error] one error found
[error] (account-impl / Compile / compileIncremental) Compilation failed
[error] Total time: 8 s, completed 19 nov. 2020 à 11:54:58
```