### PR TITLE
998: Fixed possible type clash

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -1561,7 +1561,7 @@ class ProtobufGenerator(
         lines.dropRight(1) :+ (lines.last + "\"\"\"")
       }
       .toSeq
-    fp.add("private lazy val ProtoBytes: Array[Byte] =")
+    fp.add("private lazy val ProtoBytes: _root_.scala.Array[Byte] =")
       .add("    scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(")
       .addGroupsWithDelimiter(",")(base64)
       .add("    ).mkString)")
@@ -1582,7 +1582,9 @@ class ProtobufGenerator(
           .add(
             "  val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)"
           )
-          .add("  com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(")
+          .add(
+            "  com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array("
+          )
           .addWithDelimiter(",")(file.getDependencies.asScala.map { d =>
             s"    ${d.fileDescriptorObject.fullName}.javaDescriptor"
           }.toSeq)

--- a/docs/src/main/scala/com/thesamet/docs/json/JsonProto.scala
+++ b/docs/src/main/scala/com/thesamet/docs/json/JsonProto.scala
@@ -14,7 +14,7 @@ object JsonProto extends _root_.scalapb.GeneratedFileObject {
       com.thesamet.docs.json.MyMessage,
       com.thesamet.docs.json.MyContainer
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Cgpqc29uLnByb3RvEhFjb20udGhlc2FtZXQuZG9jcxoZZ29vZ2xlL3Byb3RvYnVmL2FueS5wcm90byIhCglNeU1lc3NhZ2USF
   AoBeBgBIAEoBUIG4j8DEgF4UgF4IkYKC015Q29udGFpbmVyEjcKBm15X2FueRgBIAEoCzIULmdvb2dsZS5wcm90b2J1Zi5BbnlCC
@@ -26,7 +26,7 @@ object JsonProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       com.google.protobuf.any.AnyProto.javaDescriptor
     ))
   }

--- a/docs/src/main/scala/mytypes/duration/DurationProto.scala
+++ b/docs/src/main/scala/mytypes/duration/DurationProto.scala
@@ -13,7 +13,7 @@ object DurationProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       mytypes.duration.Duration
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Cg5kdXJhdGlvbi5wcm90bxIHbXl0eXBlcxoVc2NhbGFwYi9zY2FsYXBiLnByb3RvIk8KCER1cmF0aW9uEiYKB3NlY29uZHMYA
   SABKAVCDOI/CRIHc2Vjb25kc1IHc2Vjb25kczob4j8YIhZteXR5cGVzLk15RHVyYXRpb25UeXBlYgZwcm90bzM="""
@@ -24,7 +24,7 @@ object DurationProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       scalapb.options.ScalapbProto.javaDescriptor
     ))
   }

--- a/docs/src/main/scala/scalapb/docs/person/PersonProto.scala
+++ b/docs/src/main/scala/scalapb/docs/person/PersonProto.scala
@@ -11,7 +11,7 @@ object PersonProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       scalapb.docs.person.Person
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CgxwZXJzb24ucHJvdG8SDHNjYWxhcGIuZG9jcyLZAgoGUGVyc29uEh0KBG5hbWUYASABKAlCCeI/BhIEbmFtZVIEbmFtZRIaC
   gNhZ2UYAiABKAVCCOI/BRIDYWdlUgNhZ2USSgoJYWRkcmVzc2VzGAMgAygLMhwuc2NhbGFwYi5kb2NzLlBlcnNvbi5BZGRyZXNzQ
@@ -26,7 +26,7 @@ object PersonProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/docs/src/main/scala/scalapb/perf/protos/ProtosProto.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/ProtosProto.scala
@@ -18,7 +18,7 @@ object ProtosProto extends _root_.scalapb.GeneratedFileObject {
       scalapb.perf.protos.IntVector,
       scalapb.perf.protos.StringMessage
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Cgxwcm90b3MucHJvdG8SDHNjYWxhcGIucGVyZhoVc2NhbGFwYi9zY2FsYXBiLnByb3RvIogBCg1TaW1wbGVNZXNzYWdlEhQKA
   WkYASABKAVCBuI/AxIBaVIBaRIUCgFqGAIgASgFQgbiPwMSAWpSAWoSFAoBaxgDIAEoDEIG4j8DEgFrUgFrEjUKBWNvbG9yGAQgA
@@ -51,7 +51,7 @@ object ProtosProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       scalapb.options.ScalapbProto.javaDescriptor
     ))
   }

--- a/scalapb-runtime/src/main/scala/scalapb/options/ScalapbProto.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/ScalapbProto.scala
@@ -18,7 +18,7 @@ object ScalapbProto extends _root_.scalapb.GeneratedFileObject {
       scalapb.options.EnumValueOptions,
       scalapb.options.OneofOptions
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """ChVzY2FsYXBiL3NjYWxhcGIucHJvdG8SB3NjYWxhcGIaIGdvb2dsZS9wcm90b2J1Zi9kZXNjcmlwdG9yLnByb3RvIsgSCg5TY
   2FsYVBiT3B0aW9ucxIzCgxwYWNrYWdlX25hbWUYASABKAlCEOI/DRILcGFja2FnZU5hbWVSC3BhY2thZ2VOYW1lEjMKDGZsYXRfc
@@ -85,7 +85,7 @@ object ScalapbProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       com.google.protobuf.descriptor.DescriptorProtoCompanion.javaDescriptor
     ))
   }

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/any/AnyProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/any/AnyProto.scala
@@ -11,7 +11,7 @@ object AnyProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.any.Any
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chlnb29nbGUvcHJvdG9idWYvYW55LnByb3RvEg9nb29nbGUucHJvdG9idWYiUAoDQW55EicKCHR5cGVfdXJsGAEgASgJQgziP
   wkSB3R5cGVVcmxSB3R5cGVVcmwSIAoFdmFsdWUYAiABKAxCCuI/BxIFdmFsdWVSBXZhbHVlQm8KE2NvbS5nb29nbGUucHJvdG9id
@@ -24,7 +24,7 @@ object AnyProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/api/ApiProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/api/ApiProto.scala
@@ -16,7 +16,7 @@ object ApiProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.api.Method,
       com.google.protobuf.api.Mixin
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chlnb29nbGUvcHJvdG9idWYvYXBpLnByb3RvEg9nb29nbGUucHJvdG9idWYaJGdvb2dsZS9wcm90b2J1Zi9zb3VyY2VfY29ud
   GV4dC5wcm90bxoaZ29vZ2xlL3Byb3RvYnVmL3R5cGUucHJvdG8ipAMKA0FwaRIdCgRuYW1lGAEgASgJQgniPwYSBG5hbWVSBG5hb
@@ -41,7 +41,7 @@ object ApiProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       com.google.protobuf.source_context.SourceContextProto.javaDescriptor,
       com.google.protobuf.`type`.TypeProto.javaDescriptor
     ))

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/compiler/plugin/PluginProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/compiler/plugin/PluginProto.scala
@@ -15,7 +15,7 @@ object PluginProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.compiler.plugin.CodeGeneratorRequest,
       com.google.protobuf.compiler.plugin.CodeGeneratorResponse
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiVnb29nbGUvcHJvdG9idWYvY29tcGlsZXIvcGx1Z2luLnByb3RvEhhnb29nbGUucHJvdG9idWYuY29tcGlsZXIaIGdvb2dsZ
   S9wcm90b2J1Zi9kZXNjcmlwdG9yLnByb3RvIpQBCgdWZXJzaW9uEiAKBW1ham9yGAEgASgFQgriPwcSBW1ham9yUgVtYWpvchIgC
@@ -39,7 +39,7 @@ object PluginProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       com.google.protobuf.descriptor.DescriptorProtoCompanion.javaDescriptor
     ))
   }

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/descriptor/DescriptorProtoCompanion.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/descriptor/DescriptorProtoCompanion.scala
@@ -31,7 +31,7 @@ object DescriptorProtoCompanion extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.descriptor.SourceCodeInfo,
       com.google.protobuf.descriptor.GeneratedCodeInfo
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiBnb29nbGUvcHJvdG9idWYvZGVzY3JpcHRvci5wcm90bxIPZ29vZ2xlLnByb3RvYnVmIlgKEUZpbGVEZXNjcmlwdG9yU2V0E
   kMKBGZpbGUYASADKAsyJC5nb29nbGUucHJvdG9idWYuRmlsZURlc2NyaXB0b3JQcm90b0IJ4j8GEgRmaWxlUgRmaWxlIqkGChNGa
@@ -171,7 +171,7 @@ object DescriptorProtoCompanion extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/duration/DurationProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/duration/DurationProto.scala
@@ -11,7 +11,7 @@ object DurationProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.duration.Duration
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch5nb29nbGUvcHJvdG9idWYvZHVyYXRpb24ucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiJUCghEdXJhdGlvbhImCgdzZWNvbmRzG
   AEgASgDQgziPwkSB3NlY29uZHNSB3NlY29uZHMSIAoFbmFub3MYAiABKAVCCuI/BxIFbmFub3NSBW5hbm9zQnwKE2NvbS5nb29nb
@@ -24,7 +24,7 @@ object DurationProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/empty/EmptyProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/empty/EmptyProto.scala
@@ -11,7 +11,7 @@ object EmptyProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.empty.Empty
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIHCgVFbXB0eUJ2ChNjb20uZ29vZ2xlLnByb
   3RvYnVmQgpFbXB0eVByb3RvUAFaJ2dpdGh1Yi5jb20vZ29sYW5nL3Byb3RvYnVmL3B0eXBlcy9lbXB0efgBAaICA0dQQqoCHkdvb
@@ -23,7 +23,7 @@ object EmptyProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/field_mask/FieldMaskProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/field_mask/FieldMaskProto.scala
@@ -11,7 +11,7 @@ object FieldMaskProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.field_mask.FieldMask
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiBnb29nbGUvcHJvdG9idWYvZmllbGRfbWFzay5wcm90bxIPZ29vZ2xlLnByb3RvYnVmIi0KCUZpZWxkTWFzaxIgCgVwYXRoc
   xgBIAMoCUIK4j8HEgVwYXRoc1IFcGF0aHNCjAEKE2NvbS5nb29nbGUucHJvdG9idWZCDkZpZWxkTWFza1Byb3RvUAFaOWdvb2dsZ
@@ -24,7 +24,7 @@ object FieldMaskProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/source_context/SourceContextProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/source_context/SourceContextProto.scala
@@ -11,7 +11,7 @@ object SourceContextProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.source_context.SourceContext
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiRnb29nbGUvcHJvdG9idWYvc291cmNlX2NvbnRleHQucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiI7Cg1Tb3VyY2VDb250ZXh0E
   ioKCWZpbGVfbmFtZRgBIAEoCUIN4j8KEghmaWxlTmFtZVIIZmlsZU5hbWVClQEKE2NvbS5nb29nbGUucHJvdG9idWZCElNvdXJjZ
@@ -24,7 +24,7 @@ object SourceContextProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/struct/StructProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/struct/StructProto.scala
@@ -13,7 +13,7 @@ object StructProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.struct.Value,
       com.google.protobuf.struct.ListValue
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chxnb29nbGUvcHJvdG9idWYvc3RydWN0LnByb3RvEg9nb29nbGUucHJvdG9idWYiuwEKBlN0cnVjdBJICgZmaWVsZHMYASADK
   AsyIy5nb29nbGUucHJvdG9idWYuU3RydWN0LkZpZWxkc0VudHJ5QgviPwgSBmZpZWxkc1IGZmllbGRzGmcKC0ZpZWxkc0VudHJ5E
@@ -34,7 +34,7 @@ object StructProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/timestamp/TimestampProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/timestamp/TimestampProto.scala
@@ -11,7 +11,7 @@ object TimestampProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.timestamp.Timestamp
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch9nb29nbGUvcHJvdG9idWYvdGltZXN0YW1wLnByb3RvEg9nb29nbGUucHJvdG9idWYiVQoJVGltZXN0YW1wEiYKB3NlY29uZ
   HMYASABKANCDOI/CRIHc2Vjb25kc1IHc2Vjb25kcxIgCgVuYW5vcxgCIAEoBUIK4j8HEgVuYW5vc1IFbmFub3NCfgoTY29tLmdvb
@@ -24,7 +24,7 @@ object TimestampProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/type/TypeProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/type/TypeProto.scala
@@ -18,7 +18,7 @@ object TypeProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.`type`.EnumValue,
       com.google.protobuf.`type`.OptionProto
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chpnb29nbGUvcHJvdG9idWYvdHlwZS5wcm90bxIPZ29vZ2xlLnByb3RvYnVmGhlnb29nbGUvcHJvdG9idWYvYW55LnByb3RvG
   iRnb29nbGUvcHJvdG9idWYvc291cmNlX2NvbnRleHQucHJvdG8i4QIKBFR5cGUSHQoEbmFtZRgBIAEoCUIJ4j8GEgRuYW1lUgRuY
@@ -57,7 +57,7 @@ object TypeProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
       com.google.protobuf.any.AnyProto.javaDescriptor,
       com.google.protobuf.source_context.SourceContextProto.javaDescriptor
     ))

--- a/scalapb-runtime/src/main/scalajs/com/google/protobuf/wrappers/WrappersProto.scala
+++ b/scalapb-runtime/src/main/scalajs/com/google/protobuf/wrappers/WrappersProto.scala
@@ -19,7 +19,7 @@ object WrappersProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.wrappers.StringValue,
       com.google.protobuf.wrappers.BytesValue
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch5nb29nbGUvcHJvdG9idWYvd3JhcHBlcnMucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIvCgtEb3VibGVWYWx1ZRIgCgV2YWx1Z
   RgBIAEoAUIK4j8HEgV2YWx1ZVIFdmFsdWUiLgoKRmxvYXRWYWx1ZRIgCgV2YWx1ZRgBIAEoAkIK4j8HEgV2YWx1ZVIFdmFsdWUiL
@@ -37,7 +37,7 @@ object WrappersProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, _root_.scala.Array(
     ))
   }
   @deprecated("Use javaDescriptor instead. In a future version this will refer to scalaDescriptor.", "ScalaPB 0.5.47")

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/any/AnyProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/any/AnyProto.scala
@@ -11,7 +11,7 @@ object AnyProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.any.Any
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chlnb29nbGUvcHJvdG9idWYvYW55LnByb3RvEg9nb29nbGUucHJvdG9idWYiUAoDQW55EicKCHR5cGVfdXJsGAEgASgJQgziP
   wkSB3R5cGVVcmxSB3R5cGVVcmwSIAoFdmFsdWUYAiABKAxCCuI/BxIFdmFsdWVSBXZhbHVlQm8KE2NvbS5nb29nbGUucHJvdG9id

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/ApiProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/ApiProto.scala
@@ -16,7 +16,7 @@ object ApiProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.api.Method,
       com.google.protobuf.api.Mixin
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chlnb29nbGUvcHJvdG9idWYvYXBpLnByb3RvEg9nb29nbGUucHJvdG9idWYaJGdvb2dsZS9wcm90b2J1Zi9zb3VyY2VfY29ud
   GV4dC5wcm90bxoaZ29vZ2xlL3Byb3RvYnVmL3R5cGUucHJvdG8ipAMKA0FwaRIdCgRuYW1lGAEgASgJQgniPwYSBG5hbWVSBG5hb

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/PluginProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/PluginProto.scala
@@ -15,7 +15,7 @@ object PluginProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.compiler.plugin.CodeGeneratorRequest,
       com.google.protobuf.compiler.plugin.CodeGeneratorResponse
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiVnb29nbGUvcHJvdG9idWYvY29tcGlsZXIvcGx1Z2luLnByb3RvEhhnb29nbGUucHJvdG9idWYuY29tcGlsZXIaIGdvb2dsZ
   S9wcm90b2J1Zi9kZXNjcmlwdG9yLnByb3RvIpQBCgdWZXJzaW9uEiAKBW1ham9yGAEgASgFQgriPwcSBW1ham9yUgVtYWpvchIgC

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/DescriptorProtoCompanion.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/DescriptorProtoCompanion.scala
@@ -31,7 +31,7 @@ object DescriptorProtoCompanion extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.descriptor.SourceCodeInfo,
       com.google.protobuf.descriptor.GeneratedCodeInfo
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiBnb29nbGUvcHJvdG9idWYvZGVzY3JpcHRvci5wcm90bxIPZ29vZ2xlLnByb3RvYnVmIlgKEUZpbGVEZXNjcmlwdG9yU2V0E
   kMKBGZpbGUYASADKAsyJC5nb29nbGUucHJvdG9idWYuRmlsZURlc2NyaXB0b3JQcm90b0IJ4j8GEgRmaWxlUgRmaWxlIqkGChNGa

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/duration/DurationProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/duration/DurationProto.scala
@@ -11,7 +11,7 @@ object DurationProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.duration.Duration
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch5nb29nbGUvcHJvdG9idWYvZHVyYXRpb24ucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiJUCghEdXJhdGlvbhImCgdzZWNvbmRzG
   AEgASgDQgziPwkSB3NlY29uZHNSB3NlY29uZHMSIAoFbmFub3MYAiABKAVCCuI/BxIFbmFub3NSBW5hbm9zQnwKE2NvbS5nb29nb

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/empty/EmptyProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/empty/EmptyProto.scala
@@ -11,7 +11,7 @@ object EmptyProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.empty.Empty
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIHCgVFbXB0eUJ2ChNjb20uZ29vZ2xlLnByb
   3RvYnVmQgpFbXB0eVByb3RvUAFaJ2dpdGh1Yi5jb20vZ29sYW5nL3Byb3RvYnVmL3B0eXBlcy9lbXB0efgBAaICA0dQQqoCHkdvb

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/field_mask/FieldMaskProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/field_mask/FieldMaskProto.scala
@@ -11,7 +11,7 @@ object FieldMaskProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.field_mask.FieldMask
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiBnb29nbGUvcHJvdG9idWYvZmllbGRfbWFzay5wcm90bxIPZ29vZ2xlLnByb3RvYnVmIi0KCUZpZWxkTWFzaxIgCgVwYXRoc
   xgBIAMoCUIK4j8HEgVwYXRoc1IFcGF0aHNCjAEKE2NvbS5nb29nbGUucHJvdG9idWZCDkZpZWxkTWFza1Byb3RvUAFaOWdvb2dsZ

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/source_context/SourceContextProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/source_context/SourceContextProto.scala
@@ -11,7 +11,7 @@ object SourceContextProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.source_context.SourceContext
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """CiRnb29nbGUvcHJvdG9idWYvc291cmNlX2NvbnRleHQucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiI7Cg1Tb3VyY2VDb250ZXh0E
   ioKCWZpbGVfbmFtZRgBIAEoCUIN4j8KEghmaWxlTmFtZVIIZmlsZU5hbWVClQEKE2NvbS5nb29nbGUucHJvdG9idWZCElNvdXJjZ

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/StructProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/StructProto.scala
@@ -13,7 +13,7 @@ object StructProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.struct.Value,
       com.google.protobuf.struct.ListValue
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chxnb29nbGUvcHJvdG9idWYvc3RydWN0LnByb3RvEg9nb29nbGUucHJvdG9idWYiuwEKBlN0cnVjdBJICgZmaWVsZHMYASADK
   AsyIy5nb29nbGUucHJvdG9idWYuU3RydWN0LkZpZWxkc0VudHJ5QgviPwgSBmZpZWxkc1IGZmllbGRzGmcKC0ZpZWxkc0VudHJ5E

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/timestamp/TimestampProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/timestamp/TimestampProto.scala
@@ -11,7 +11,7 @@ object TimestampProto extends _root_.scalapb.GeneratedFileObject {
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
       com.google.protobuf.timestamp.Timestamp
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch9nb29nbGUvcHJvdG9idWYvdGltZXN0YW1wLnByb3RvEg9nb29nbGUucHJvdG9idWYiVQoJVGltZXN0YW1wEiYKB3NlY29uZ
   HMYASABKANCDOI/CRIHc2Vjb25kc1IHc2Vjb25kcxIgCgVuYW5vcxgCIAEoBUIK4j8HEgVuYW5vc1IFbmFub3NCfgoTY29tLmdvb

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/TypeProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/TypeProto.scala
@@ -18,7 +18,7 @@ object TypeProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.`type`.EnumValue,
       com.google.protobuf.`type`.OptionProto
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Chpnb29nbGUvcHJvdG9idWYvdHlwZS5wcm90bxIPZ29vZ2xlLnByb3RvYnVmGhlnb29nbGUvcHJvdG9idWYvYW55LnByb3RvG
   iRnb29nbGUvcHJvdG9idWYvc291cmNlX2NvbnRleHQucHJvdG8i4QIKBFR5cGUSHQoEbmFtZRgBIAEoCUIJ4j8GEgRuYW1lUgRuY

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/WrappersProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/WrappersProto.scala
@@ -19,7 +19,7 @@ object WrappersProto extends _root_.scalapb.GeneratedFileObject {
       com.google.protobuf.wrappers.StringValue,
       com.google.protobuf.wrappers.BytesValue
     )
-  private lazy val ProtoBytes: Array[Byte] =
+  private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
   """Ch5nb29nbGUvcHJvdG9idWYvd3JhcHBlcnMucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIvCgtEb3VibGVWYWx1ZRIgCgV2YWx1Z
   RgBIAEoAUIK4j8HEgV2YWx1ZVIFdmFsdWUiLgoKRmxvYXRWYWx1ZRIgCgV2YWx1ZRgBIAEoAkIK4j8HEgV2YWx1ZVIFdmFsdWUiL


### PR DESCRIPTION
In case message is named `Array`, generated code will not compile.
Such situation happenend in MySQL X Protocol.

https://github.com/scalapb/ScalaPB/issues/998