### PR TITLE
Extend FieldMaskUtils functionality

### DIFF
--- a/e2e/src/main/protobuf/google/protobuf/unittest.proto
+++ b/e2e/src/main/protobuf/google/protobuf/unittest.proto
@@ -376,6 +376,12 @@ message TestRequiredForeign {
   optional int32 dummy = 3;
 }
 
+message TestRequiredMessage {
+  optional TestRequired optional_message = 1;
+  repeated TestRequired repeated_message = 2;
+  required TestRequired required_message = 3;
+}
+
 // Test that we can use NestedMessage from outside TestAllTypes.
 message TestForeignNested {
   optional TestAllTypes.NestedMessage foreign_nested = 1;

--- a/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -2,9 +2,56 @@ package scalapb
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import protobuf_unittest.unittest.NestedTestAllTypes
+import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
 
 class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
+
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L94-L266
+  "applyToMessage" should "apply field mask to a message" in {
+    val value = TestAllTypes(
+      optionalInt32 = Some(1234),
+      optionalNestedMessage = Some(
+        TestAllTypes.NestedMessage(
+          bb = Some(5678)
+        )
+      ),
+      repeatedInt32 = List(4321),
+      repeatedNestedMessage = List(
+        TestAllTypes.NestedMessage(
+          bb = Some(8765)
+        )
+      )
+    )
+    val source = NestedTestAllTypes(
+      payload = Some(value),
+      child = Some(
+        NestedTestAllTypes(
+          payload = Some(value)
+        )
+      )
+    )
+    FieldMaskTree(Seq("payload.optional_int32")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        payload = Some(
+          TestAllTypes(
+            optionalInt32 = Some(1234)
+          )
+        )
+      )
+    )
+  }
+
+  "containsField" should "check that field is present" in {
+    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskTree(Seq("payload.optional_int32")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.CHILD_FIELD_NUMBER
+    ) must be(false)
+  }
 
   def isValidFor(paths: Seq[String]): Boolean = {
     FieldMaskTree(paths).isValidFor[NestedTestAllTypes]
@@ -25,17 +72,4 @@ class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
     isValidFor(Seq("payload.repeated_nested_message.bb")) must be(false)
     isValidFor(Seq("payload.optional_int32.bb")) must be(false)
   }
-
-  "containsField" should "check that field is present" in {
-    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
-      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
-    ) must be(true)
-    FieldMaskTree(Seq("payload.optional_int32")).containsField[NestedTestAllTypes](
-      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
-    ) must be(true)
-    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
-      NestedTestAllTypes.CHILD_FIELD_NUMBER
-    ) must be(false)
-  }
-
 }

--- a/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -6,7 +6,7 @@ import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
 
 class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L94-L266
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L94-L193
   "applyToMessage" should "apply field mask to a message" in {
     val value = TestAllTypes(
       optionalInt32 = Some(1234),
@@ -39,6 +39,102 @@ class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
         )
       )
     )
+    FieldMaskTree(Seq("payload.optional_nested_message")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        payload = Some(
+          TestAllTypes(
+            optionalNestedMessage = Some(
+              TestAllTypes.NestedMessage(
+                bb = Some(5678)
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("payload.repeated_int32")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        payload = Some(
+          TestAllTypes(
+            repeatedInt32 = List(4321)
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("payload.repeated_nested_message")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        payload = Some(
+          TestAllTypes(
+            repeatedNestedMessage = List(
+              TestAllTypes.NestedMessage(
+                bb = Some(8765)
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("child.payload.optional_int32")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        child = Some(
+          NestedTestAllTypes(
+            payload = Some(
+              TestAllTypes(
+                optionalInt32 = Some(1234)
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("child.payload.optional_nested_message")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        child = Some(
+          NestedTestAllTypes(
+            payload = Some(
+              TestAllTypes(
+                optionalNestedMessage = Some(
+                  TestAllTypes.NestedMessage(
+                    bb = Some(5678)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("child.payload.repeated_int32")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        child = Some(
+          NestedTestAllTypes(
+            payload = Some(
+              TestAllTypes(
+                repeatedInt32 = List(4321)
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("child.payload.repeated_nested_message")).applyToMessage(source) must be(
+      NestedTestAllTypes(
+        child = Some(
+          NestedTestAllTypes(
+            payload = Some(
+              TestAllTypes(
+                repeatedNestedMessage = List(
+                  TestAllTypes.NestedMessage(
+                    bb = Some(8765)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    FieldMaskTree(Seq("child", "payload")).applyToMessage(source) must be(source)
   }
 
   "containsField" should "check that field is present" in {

--- a/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -2,7 +2,7 @@ package scalapb
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
+import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes, TestRequired, TestRequiredMessage}
 
 class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
 
@@ -135,6 +135,21 @@ class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
       )
     )
     FieldMaskTree(Seq("child", "payload")).applyToMessage(source) must be(source)
+  }
+
+  // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L174-L201
+  "applyToMessage" should "thrown an exception when required field is not selected" in {
+    val value = TestRequired(
+      a = 4321,
+      b = 8765,
+      c = 233333
+    )
+    val source = TestRequiredMessage(
+      requiredMessage = value
+    )
+    a[NoSuchElementException] shouldBe thrownBy(
+      FieldMaskTree(Seq("required_message.b", "required_message.c")).applyToMessage(source)
+    )
   }
 
   "containsField" should "check that field is present" in {

--- a/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -1,0 +1,41 @@
+package scalapb
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import protobuf_unittest.unittest.NestedTestAllTypes
+
+class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
+
+  def isValidFor(paths: Seq[String]): Boolean = {
+    FieldMaskTree(paths).isValidFor[NestedTestAllTypes]
+  }
+
+  "isValid" should "pass for valid NestedTestAllTypes masks" in {
+    isValidFor(Seq("payload")) must be(true)
+    isValidFor(Seq("payload.optional_int32")) must be(true)
+    isValidFor(Seq("payload.repeated_int32")) must be(true)
+    isValidFor(Seq("payload.optional_nested_message")) must be(true)
+    isValidFor(Seq("payload.optional_nested_message.bb")) must be(true)
+  }
+
+  "isValid" should "fail for invalid NestedTestAllTypes masks" in {
+    isValidFor(Seq("nonexist")) must be(false)
+    isValidFor(Seq("payload.nonexist")) must be(false)
+    isValidFor(Seq("payload,nonexist")) must be(false)
+    isValidFor(Seq("payload.repeated_nested_message.bb")) must be(false)
+    isValidFor(Seq("payload.optional_int32.bb")) must be(false)
+  }
+
+  "containsField" should "check that field is present" in {
+    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskTree(Seq("payload.optional_int32")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskTree(Seq("payload")).containsField[NestedTestAllTypes](
+      NestedTestAllTypes.CHILD_FIELD_NUMBER
+    ) must be(false)
+  }
+
+}

--- a/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -6,7 +6,7 @@ import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
 
 class FieldMaskTreeSpec extends AnyFlatSpec with Matchers {
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L94-L193
+  // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L203-L312
   "applyToMessage" should "apply field mask to a message" in {
     val value = TestAllTypes(
       optionalInt32 = Some(1234),

--- a/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
@@ -1,0 +1,78 @@
+package scalapb
+
+import com.google.protobuf.field_mask.FieldMask
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
+
+class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
+
+  def isValid(paths: Seq[String]): Boolean = {
+    FieldMaskUtil.isValid[NestedTestAllTypes](FieldMask(paths))
+  }
+
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L41-L75
+  "isValid" should "pass for valid NestedTestAllTypes masks" in {
+    isValid(Seq("payload")) must be(true)
+    isValid(Seq("payload.optional_int32")) must be(true)
+    isValid(Seq("payload.repeated_int32")) must be(true)
+    isValid(Seq("payload.optional_nested_message")) must be(true)
+    isValid(Seq("payload.optional_nested_message.bb")) must be(true)
+  }
+
+  "isValid" should "fail for invalid NestedTestAllTypes masks" in {
+    isValid(Seq("nonexist")) must be(false)
+    isValid(Seq("payload.nonexist")) must be(false)
+    isValid(Seq("payload,nonexist")) must be(false)
+    isValid(Seq("payload.repeated_nested_message.bb")) must be(false)
+    isValid(Seq("payload.optional_int32.bb")) must be(false)
+  }
+
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L124-L147
+  "fromFieldNumbers" should "construct TestAllTypes mask" in {
+    FieldMaskUtil.fromFieldNumbers[TestAllTypes]() must be(FieldMask())
+    FieldMaskUtil.fromFieldNumbers[TestAllTypes](
+      TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER
+    ) must be(FieldMask(Seq("optional_int32")))
+    FieldMaskUtil.fromFieldNumbers[TestAllTypes](
+      TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER,
+      TestAllTypes.OPTIONAL_INT64_FIELD_NUMBER
+    ) must be(FieldMask(Seq("optional_int32", "optional_int64")))
+  }
+
+  "fromFieldNumbers" should "throw an exception for invalid field" in {
+    val invalidFieldNumber = 1000
+    a[NullPointerException] shouldBe thrownBy(
+      FieldMaskUtil.fromFieldNumbers[TestAllTypes](invalidFieldNumber)
+    )
+  }
+
+  "selectFieldNumbers" should "construct NestedTestAllTypes mask using a predicate" in {
+    FieldMaskUtil.selectFieldNumbers[NestedTestAllTypes](_ => true) must be(
+      FieldMask(Seq("child", "payload", "repeated_child"))
+    )
+    FieldMaskUtil.selectFieldNumbers[NestedTestAllTypes](_ => false) must be(FieldMask())
+    FieldMaskUtil.selectFieldNumbers[NestedTestAllTypes](
+      Set(
+        NestedTestAllTypes.CHILD_FIELD_NUMBER,
+        NestedTestAllTypes.PAYLOAD_FIELD_NUMBER,
+      )
+    ) must be(FieldMask(Seq("child", "payload")))
+  }
+
+  "containsField" should "check that field is present" in {
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload")),
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload.optional_int32")),
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload")),
+      NestedTestAllTypes.CHILD_FIELD_NUMBER
+    ) must be(false)
+  }
+
+}

--- a/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
@@ -7,25 +7,35 @@ import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
 
 class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
 
-  def isValid(paths: Seq[String]): Boolean = {
-    FieldMaskUtil.isValid[NestedTestAllTypes](FieldMask(paths))
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L202-L212
+  "applyFieldMask" should "apply field mask to a message" in {
+    val message = NestedTestAllTypes(
+      payload = Some(TestAllTypes(
+        optionalInt32 = Some(1234)
+      ))
+    )
+    val fieldMask = FieldMask(Seq("payload"))
+
+    FieldMaskUtil.applyFieldMask(message, fieldMask).payload must be(
+      Some(TestAllTypes(
+        optionalInt32 = Some(1234)
+      ))
+    )
   }
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L41-L75
-  "isValid" should "pass for valid NestedTestAllTypes masks" in {
-    isValid(Seq("payload")) must be(true)
-    isValid(Seq("payload.optional_int32")) must be(true)
-    isValid(Seq("payload.repeated_int32")) must be(true)
-    isValid(Seq("payload.optional_nested_message")) must be(true)
-    isValid(Seq("payload.optional_nested_message.bb")) must be(true)
-  }
-
-  "isValid" should "fail for invalid NestedTestAllTypes masks" in {
-    isValid(Seq("nonexist")) must be(false)
-    isValid(Seq("payload.nonexist")) must be(false)
-    isValid(Seq("payload,nonexist")) must be(false)
-    isValid(Seq("payload.repeated_nested_message.bb")) must be(false)
-    isValid(Seq("payload.optional_int32.bb")) must be(false)
+  "containsField" should "check that field is present" in {
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload")),
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload.optional_int32")),
+      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
+    ) must be(true)
+    FieldMaskUtil.containsField[NestedTestAllTypes](
+      FieldMask(Seq("payload")),
+      NestedTestAllTypes.CHILD_FIELD_NUMBER
+    ) must be(false)
   }
 
   // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L124-L147
@@ -47,6 +57,27 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  def isValid(paths: Seq[String]): Boolean = {
+    FieldMaskUtil.isValid[NestedTestAllTypes](FieldMask(paths))
+  }
+
+  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L41-L75
+  "isValid" should "pass for valid NestedTestAllTypes masks" in {
+    isValid(Seq("payload")) must be(true)
+    isValid(Seq("payload.optional_int32")) must be(true)
+    isValid(Seq("payload.repeated_int32")) must be(true)
+    isValid(Seq("payload.optional_nested_message")) must be(true)
+    isValid(Seq("payload.optional_nested_message.bb")) must be(true)
+  }
+
+  "isValid" should "fail for invalid NestedTestAllTypes masks" in {
+    isValid(Seq("nonexist")) must be(false)
+    isValid(Seq("payload.nonexist")) must be(false)
+    isValid(Seq("payload,nonexist")) must be(false)
+    isValid(Seq("payload.repeated_nested_message.bb")) must be(false)
+    isValid(Seq("payload.optional_int32.bb")) must be(false)
+  }
+
   "selectFieldNumbers" should "construct NestedTestAllTypes mask using a predicate" in {
     FieldMaskUtil.selectFieldNumbers[NestedTestAllTypes](_ => true) must be(
       FieldMask(Seq("child", "payload", "repeated_child"))
@@ -58,21 +89,6 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
         NestedTestAllTypes.PAYLOAD_FIELD_NUMBER,
       )
     ) must be(FieldMask(Seq("child", "payload")))
-  }
-
-  "containsField" should "check that field is present" in {
-    FieldMaskUtil.containsField[NestedTestAllTypes](
-      FieldMask(Seq("payload")),
-      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
-    ) must be(true)
-    FieldMaskUtil.containsField[NestedTestAllTypes](
-      FieldMask(Seq("payload.optional_int32")),
-      NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
-    ) must be(true)
-    FieldMaskUtil.containsField[NestedTestAllTypes](
-      FieldMask(Seq("payload")),
-      NestedTestAllTypes.CHILD_FIELD_NUMBER
-    ) must be(false)
   }
 
 }

--- a/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
@@ -23,16 +23,16 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  "containsField" should "check that field is present" in {
-    FieldMaskUtil.containsField[NestedTestAllTypes](
+  "containsFieldNumber" should "check that field is present" in {
+    FieldMaskUtil.containsFieldNumber[NestedTestAllTypes](
       FieldMask(Seq("payload")),
       NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
     ) must be(true)
-    FieldMaskUtil.containsField[NestedTestAllTypes](
+    FieldMaskUtil.containsFieldNumber[NestedTestAllTypes](
       FieldMask(Seq("payload.optional_int32")),
       NestedTestAllTypes.PAYLOAD_FIELD_NUMBER
     ) must be(true)
-    FieldMaskUtil.containsField[NestedTestAllTypes](
+    FieldMaskUtil.containsFieldNumber[NestedTestAllTypes](
       FieldMask(Seq("payload")),
       NestedTestAllTypes.CHILD_FIELD_NUMBER
     ) must be(false)
@@ -40,21 +40,19 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
 
   // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L124-L147
   "fromFieldNumbers" should "construct TestAllTypes mask" in {
-    FieldMaskUtil.fromFieldNumbers[TestAllTypes]() must be(FieldMask())
+    FieldMaskUtil.fromFieldNumbers[TestAllTypes]() must be(Some(FieldMask()))
     FieldMaskUtil.fromFieldNumbers[TestAllTypes](
       TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER
-    ) must be(FieldMask(Seq("optional_int32")))
+    ) must be(Some(FieldMask(Seq("optional_int32"))))
     FieldMaskUtil.fromFieldNumbers[TestAllTypes](
       TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER,
       TestAllTypes.OPTIONAL_INT64_FIELD_NUMBER
-    ) must be(FieldMask(Seq("optional_int32", "optional_int64")))
+    ) must be(Some(FieldMask(Seq("optional_int32", "optional_int64"))))
   }
 
-  "fromFieldNumbers" should "throw an exception for invalid field" in {
+  "fromFieldNumbers" should "return None for invalid field numbers" in {
     val invalidFieldNumber = 1000
-    a[NullPointerException] shouldBe thrownBy(
-      FieldMaskUtil.fromFieldNumbers[TestAllTypes](invalidFieldNumber)
-    )
+    FieldMaskUtil.fromFieldNumbers[TestAllTypes](invalidFieldNumber) must be(None)
   }
 
   def isValid(paths: Seq[String]): Boolean = {

--- a/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
+++ b/e2e/src/test/scala/scalapb/FieldMaskUtilsSpec.scala
@@ -7,7 +7,7 @@ import protobuf_unittest.unittest.{NestedTestAllTypes, TestAllTypes}
 
 class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L202-L212
+  // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L254-L264
   "applyFieldMask" should "apply field mask to a message" in {
     val message = NestedTestAllTypes(
       payload = Some(TestAllTypes(
@@ -38,7 +38,7 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
     ) must be(false)
   }
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L124-L147
+  // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L126-L149
   "fromFieldNumbers" should "construct TestAllTypes mask" in {
     FieldMaskUtil.fromFieldNumbers[TestAllTypes]() must be(Some(FieldMask()))
     FieldMaskUtil.fromFieldNumbers[TestAllTypes](
@@ -59,7 +59,7 @@ class FieldMaskUtilsSpec extends AnyFlatSpec with Matchers {
     FieldMaskUtil.isValid[NestedTestAllTypes](FieldMask(paths))
   }
 
-  // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L41-L75
+  // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L43-L77
   "isValid" should "pass for valid NestedTestAllTypes masks" in {
     isValid(Seq("payload")) must be(true)
     isValid(Seq("payload.optional_int32")) must be(true)

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
@@ -67,7 +67,7 @@ private[scalapb] case class FieldMaskTree(nodes: SortedMap[String, FieldMaskTree
   }
 }
 
-object FieldMaskTree {
+private[scalapb] object FieldMaskTree {
 
   val Empty: FieldMaskTree = FieldMaskTree(SortedMap.empty[String, FieldMaskTree])
 

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
@@ -1,0 +1,80 @@
+package scalapb
+
+import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
+import com.google.protobuf.field_mask.FieldMask
+
+import scala.collection.SortedMap
+
+private[scalapb] case class FieldMaskTree(nodes: SortedMap[String, FieldMaskTree]) {
+
+  def fieldMask: FieldMask = FieldMask(paths)
+
+  private def paths: Vector[String] = {
+    nodes.toVector.flatMap {
+      case (field, FieldMaskTree.Empty) => Vector(field)
+      case (field, subTree) =>
+        subTree.paths.map(path => s"$field${FieldMaskTree.FieldSeparator}$path")
+    }
+  }
+
+  def isValidFor[M <: GeneratedMessage: GeneratedMessageCompanion]: Boolean = {
+    val descriptor = implicitly[GeneratedMessageCompanion[M]].javaDescriptor
+    isValidFor(descriptor)
+  }
+
+  private def isValidFor(descriptor: Descriptor): Boolean = {
+    nodes.forall { case (field, tree) =>
+      Option(descriptor.findFieldByName(field)) match {
+        case None => false
+        case Some(field) =>
+          if (tree == FieldMaskTree.Empty) {
+            true
+          } else if (!field.isRepeated && field.getJavaType == FieldDescriptor.JavaType.MESSAGE) {
+            tree.isValidFor(field.getMessageType)
+          } else {
+            false
+          }
+      }
+    }
+  }
+}
+
+object FieldMaskTree {
+
+  val Empty: FieldMaskTree = FieldMaskTree(SortedMap.empty[String, FieldMaskTree])
+
+  private val FieldSeparator = '.'
+
+  def apply(paths: Seq[String]): FieldMaskTree = {
+    paths.map(fromPath).foldLeft[FieldMaskTree](Empty)(union)
+  }
+
+  def apply(fieldMask: FieldMask): FieldMaskTree = {
+    apply(fieldMask.paths)
+  }
+
+  def union(tree1: FieldMaskTree, tree2: FieldMaskTree): FieldMaskTree = (tree1, tree2) match {
+    case (Empty, tree) => tree
+    case (tree, Empty) => tree
+    case (FieldMaskTree(nodes1), FieldMaskTree(nodes2)) =>
+      val fields: Seq[String] = (nodes1.keySet ++ nodes2.keySet).toSeq
+      val tree = SortedMap(fields.map { field =>
+        val subTree = (nodes1.get(field), nodes2.get(field)) match {
+          case (Some(Empty), _) => Empty
+          case (_, Some(Empty)) => Empty
+          case (mask1, mask2)   => union(mask1.getOrElse(Empty), mask2.getOrElse(Empty))
+        }
+        field -> subTree
+      }: _*)
+      FieldMaskTree(tree)
+  }
+
+  private def fromPath(path: String): FieldMaskTree = {
+    path
+      .split(FieldSeparator)
+      .filter(_.nonEmpty)
+      .foldRight[FieldMaskTree](Empty) { case (field, tree) =>
+        FieldMaskTree(SortedMap(field -> tree))
+      }
+  }
+}

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskTree.scala
@@ -7,6 +7,14 @@ import scala.collection.SortedMap
 
 private[scalapb] case class FieldMaskTree(nodes: SortedMap[String, FieldMaskTree]) {
 
+  def containsField[M <: GeneratedMessage: GeneratedMessageCompanion](fieldNumber: Int): Boolean = {
+    val descriptor = implicitly[GeneratedMessageCompanion[M]].javaDescriptor
+    Option(descriptor.findFieldByNumber(fieldNumber)) match {
+      case Some(field) => nodes.contains(field.getName)
+      case None        => false
+    }
+  }
+
   def fieldMask: FieldMask = FieldMask(paths)
 
   private def paths: Vector[String] = {

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
@@ -120,6 +120,13 @@ object FieldMaskUtil {
     FieldMask(result)
   }
 
+  def applyFieldMask[M <: GeneratedMessage: GeneratedMessageCompanion](
+      message: M,
+      fieldMask: FieldMask
+  ): M = {
+    FieldMaskTree(fieldMask).applyToMessage(message)
+  }
+
   def containsField[M <: GeneratedMessage: GeneratedMessageCompanion](
       fieldMask: FieldMask,
       fieldNumber: Int

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
@@ -119,4 +119,15 @@ object FieldMaskUtil {
       .toList
     FieldMask(result)
   }
+
+  def isValid[M <: GeneratedMessage: GeneratedMessageCompanion](fieldMask: FieldMask): Boolean = {
+    FieldMaskTree(fieldMask).isValidFor[M]
+  }
+
+  def union(fieldMask: FieldMask, otherMasks: FieldMask*): FieldMask = {
+    val tree = otherMasks.foldLeft(FieldMaskTree(fieldMask)) { case (acc, nextMask) =>
+      FieldMaskTree.union(acc, FieldMaskTree(nextMask))
+    }
+    tree.fieldMask
+  }
 }

--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
@@ -120,6 +120,8 @@ object FieldMaskUtil {
     FieldMask(result)
   }
 
+  /** Applies a field mask to a message.
+    */
   def applyFieldMask[M <: GeneratedMessage: GeneratedMessageCompanion](
       message: M,
       fieldMask: FieldMask
@@ -127,6 +129,8 @@ object FieldMaskUtil {
     FieldMaskTree(fieldMask).applyToMessage(message)
   }
 
+  /** Checks that a field mask selects a certain message field number.
+    */
   def containsFieldNumber[M <: GeneratedMessage: GeneratedMessageCompanion](
       fieldMask: FieldMask,
       fieldNumber: Int
@@ -134,10 +138,15 @@ object FieldMaskUtil {
     FieldMaskTree(fieldMask).containsField[M](fieldNumber)
   }
 
+  /** Checks that field masks corresponds to message schema.
+    */
   def isValid[M <: GeneratedMessage: GeneratedMessageCompanion](fieldMask: FieldMask): Boolean = {
     FieldMaskTree(fieldMask).isValidFor[M]
   }
 
+  /** Constructs a field mask based on message field numbers.
+    * @return Some(mask) if all fields number are valid, [[None]] otherwise.
+    */
   def fromFieldNumbers[M <: GeneratedMessage: GeneratedMessageCompanion](
       fieldNumbers: Int*
   ): Option[FieldMask] = {
@@ -152,6 +161,8 @@ object FieldMaskUtil {
     fieldNames.map(names => FieldMask(paths = names))
   }
 
+  /** Constructs a field mask based on a predicate for message field numbers.
+    */
   def selectFieldNumbers[M <: GeneratedMessage: GeneratedMessageCompanion](
       fieldNumberPredicate: Int => Boolean
   ): FieldMask = {
@@ -160,6 +171,8 @@ object FieldMaskUtil {
     fromFieldNumbers[M](fieldNumbers: _*).get
   }
 
+  /** Unions two or more field masks.
+    */
   def union(fieldMask: FieldMask, otherMasks: FieldMask*): FieldMask = {
     val tree = otherMasks.foldLeft(FieldMaskTree(fieldMask)) { case (acc, nextMask) =>
       FieldMaskTree.union(acc, FieldMaskTree(nextMask))

--- a/scalapb-runtime/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -28,7 +28,7 @@ class FieldMaskTreeSpec extends FunSuite {
     // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L64-L69
     val tree1 = FieldMaskTree(Seq("foo", "bar.baz", "bar.quz"))
     assertEquals(tree1.fieldMask, FieldMask(Seq("bar.baz", "bar.quz", "foo")))
-    val tree2 = FieldMaskTree(Seq("foo.bar", "bar"))
+    val tree2 = FieldMaskTree.union(tree1, FieldMaskTree(Seq("foo.bar", "bar")))
     assertEquals(tree2.fieldMask, FieldMask(Seq("bar", "foo")))
   }
 }

--- a/scalapb-runtime/src/test/scala/scalapb/FieldMaskTreeSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/FieldMaskTreeSpec.scala
@@ -1,0 +1,34 @@
+package scalapb
+
+import com.google.protobuf.field_mask.FieldMask
+import munit.FunSuite
+
+class FieldMaskTreeSpec extends FunSuite {
+  test("testAddFieldPath") {
+    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L39-L62
+    val tree1 = FieldMaskTree.Empty
+    assertEquals(tree1.fieldMask, FieldMask())
+    val tree2 = FieldMaskTree.union(tree1, FieldMaskTree(Seq("")))
+    assertEquals(tree2.fieldMask, FieldMask())
+    val tree3 = FieldMaskTree.union(tree2, FieldMaskTree(Seq("foo")))
+    assertEquals(tree3.fieldMask, FieldMask(Seq("foo")))
+    val tree4 = FieldMaskTree.union(tree3, FieldMaskTree(Seq("foo")))
+    assertEquals(tree4.fieldMask, FieldMask(Seq("foo")))
+    val tree5 = FieldMaskTree.union(tree4, FieldMaskTree(Seq("bar.baz")))
+    assertEquals(tree5.fieldMask, FieldMask(Seq("bar.baz", "foo")))
+    val tree6 = FieldMaskTree.union(tree5, FieldMaskTree(Seq("foo.bar")))
+    assertEquals(tree6.fieldMask, FieldMask(Seq("bar.baz", "foo")))
+    val tree7 = FieldMaskTree.union(tree6, FieldMaskTree(Seq("bar.quz")))
+    assertEquals(tree7.fieldMask, FieldMask(Seq("bar.baz", "bar.quz", "foo")))
+    val tree8 = FieldMaskTree.union(tree7, FieldMaskTree(Seq("bar")))
+    assertEquals(tree8.fieldMask, FieldMask(Seq("bar", "foo")))
+  }
+
+  test("testMergeFromFieldMask") {
+    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java#L64-L69
+    val tree1 = FieldMaskTree(Seq("foo", "bar.baz", "bar.quz"))
+    assertEquals(tree1.fieldMask, FieldMask(Seq("bar.baz", "bar.quz", "foo")))
+    val tree2 = FieldMaskTree(Seq("foo.bar", "bar"))
+    assertEquals(tree2.fieldMask, FieldMask(Seq("bar", "foo")))
+  }
+}

--- a/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 
 class FieldMaskUtilSpec extends FunSuite {
   test("toJsonString") {
-    // https://github.com/google/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java#L761-L770
+    // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java#L804-L813
     val x      = FieldMask(Seq("foo.bar", "baz", "foo_bar.baz"))
     val expect = "foo.bar,baz,fooBar.baz"
     val json   = FieldMaskUtil.toJsonString(x)
@@ -13,7 +13,7 @@ class FieldMaskUtilSpec extends FunSuite {
   }
 
   test("union") {
-    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L175-L182
+    // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L209-L216
     val mask1  = FieldMask(Seq("foo", "bar.baz", "bar.quz"))
     val mask2  = FieldMask(Seq("foo.bar", "bar"))
     val expect = FieldMask(Seq("bar", "foo"))
@@ -22,7 +22,7 @@ class FieldMaskUtilSpec extends FunSuite {
   }
 
   test("union using var args") {
-    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L184-L191
+    // https://github.com/protocolbuffers/protobuf/blob/v3.14.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L218-L225
     val mask1  = FieldMask(Seq("foo"))
     val mask2  = FieldMask(Seq("foo.bar", "bar.quz"))
     val mask3  = FieldMask(Seq("bar.quz"))

--- a/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
@@ -4,11 +4,31 @@ import com.google.protobuf.field_mask.FieldMask
 import munit.FunSuite
 
 class FieldMaskUtilSpec extends FunSuite {
-  test("fieldMasks") {
+  test("toJsonString") {
     // https://github.com/google/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java#L761-L770
     val x      = FieldMask(Seq("foo.bar", "baz", "foo_bar.baz"))
     val expect = "foo.bar,baz,fooBar.baz"
     val json   = FieldMaskUtil.toJsonString(x)
     assertEquals(json, expect)
+  }
+
+  test("union") {
+    // https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L209-L216
+    val mask1  = FieldMask(Seq("foo", "bar.baz", "bar.quz"))
+    val mask2  = FieldMask(Seq("foo.bar", "bar"))
+    val expect = FieldMask(Seq("bar", "foo"))
+    val union  = FieldMaskUtil.union(mask1, mask2)
+    assertEquals(union, expect)
+  }
+
+  test("union using var args") {
+    // https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L218-L225
+    val mask1  = FieldMask(Seq("foo"))
+    val mask2  = FieldMask(Seq("foo.bar", "bar.quz"))
+    val mask3  = FieldMask(Seq("bar.quz"))
+    val mask4  = FieldMask(Seq("bar"))
+    val expect = FieldMask(Seq("bar", "foo"))
+    val union  = FieldMaskUtil.union(mask1, mask2, mask3, mask4)
+    assertEquals(union, expect)
   }
 }

--- a/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/FieldMaskUtilSpec.scala
@@ -13,7 +13,7 @@ class FieldMaskUtilSpec extends FunSuite {
   }
 
   test("union") {
-    // https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L209-L216
+    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L175-L182
     val mask1  = FieldMask(Seq("foo", "bar.baz", "bar.quz"))
     val mask2  = FieldMask(Seq("foo.bar", "bar"))
     val expect = FieldMask(Seq("bar", "foo"))
@@ -22,7 +22,7 @@ class FieldMaskUtilSpec extends FunSuite {
   }
 
   test("union using var args") {
-    // https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L218-L225
+    // https://github.com/protocolbuffers/protobuf/blob/v3.6.0/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java#L184-L191
     val mask1  = FieldMask(Seq("foo"))
     val mask2  = FieldMask(Seq("foo.bar", "bar.quz"))
     val mask3  = FieldMask(Seq("bar.quz"))


### PR DESCRIPTION
FieldMaskUtils is currently missing several features from Java version such as:
* Ability to validate that field mask is formed correctly for a protobuf message
* Merge two or more field masks 
* Apply a field mask to a message

This PR aims to reimplement some of the missing methods in FieldMaskUtils. Original Java test cases were used when it was possible.

The following methods were added:

**applyToMessage**

Applies a field mask to a message.

```scala
def applyToMessage[M <: GeneratedMessage: GeneratedMessageCompanion](message: M): M
```

Java version:

```java
public static void merge(FieldMask mask, Message source, Message.Builder destination)
```

**fromFieldNumbers**

Constructs a field mask based on message numbers. Returns `None` when field number does not exist.

```scala
def fromFieldNumbers[M <: GeneratedMessage: GeneratedMessageCompanion](fieldNumbers: Int*): Option[FieldMask]
```

Java version:

```java
public static FieldMask fromFieldNumbers(Class<? extends Message> type, int... fieldNumbers)
```

**selectFieldNumbers**

A safer version of `fromFieldNumbers`, restrict to select only valid field numbers based on a predicate. Useful to define masks for all fields.

```scala
def selectFieldNumbers[M <: GeneratedMessage: GeneratedMessageCompanion](fieldNumberPredicate: Int => Boolean): FieldMask
```

**isValid**

Checks that field masks corresponds to a message schema,

```scala
def isValid[M <: GeneratedMessage: GeneratedMessageCompanion](fieldMask: FieldMask): Boolean
```

Java version:

```java
public static boolean isValid(Class<? extends Message> type, FieldMask fieldMask)
```

**containsFieldNumber**

Checks that field mask selects a certain field.

```scala
def containsFieldNumber[M <: GeneratedMessage: GeneratedMessageCompanion](fieldMask: FieldMask, fieldNumber: Int): Boolean
```

**union**

Unions two or more field masks.

```scala
def union(fieldMask: FieldMask, otherMasks: FieldMask*): FieldMask
```

Java version:

```java
public static FieldMask union(FieldMask firstMask, FieldMask secondMask, FieldMask... otherMasks)
```
