### PR TITLE
fix scaladoc generation

### DIFF
--- a/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala
@@ -145,7 +145,7 @@ object FieldMaskUtil {
   }
 
   /** Constructs a field mask based on message field numbers.
-    * @return Some(mask) if all fields number are valid, [[None]] otherwise.
+    * @return Some(mask) if all fields number are valid, `None` otherwise.
     */
   def fromFieldNumbers[M <: GeneratedMessage: GeneratedMessageCompanion](
       fieldNumbers: Int*


### PR DESCRIPTION
https://github.com/scalapb/ScalaPB/runs/1819366035#step:7:252

```
[error] /home/runner/work/ScalaPB/ScalaPB/scalapb-runtime/src/main/scala/scalapb/FieldMaskUtil.scala:147:3: Could not find any member to link for "None".
[error]   /** Constructs a field mask based on message field numbers.
[error]   ^
[error] one error found
```