### PR TITLE
Allow negative nanos of Duration

### DIFF
--- a/e2e/src/test/scalajvm/TimestampsSpec.scala
+++ b/e2e/src/test/scalajvm/TimestampsSpec.scala
@@ -38,4 +38,20 @@ class TimestampsSpec extends AnyFlatSpec with Matchers {
         duration must be(Duration(1, 333000000))
         duration.asJavaDuration must be(jtDuration.between(t1, t2))
     }
+
+    "Durations" should "be valid when their seconds and nanos are in defined range and have same sign" in {
+        Duration.isValid(Duration(315576000001L, 0)) must be(false)
+        Duration.isValid(Duration(315576000000L, 999999999)) must be(true)
+        Duration.isValid(Duration(315576000000L, 0)) must be(true)
+        Duration.isValid(Duration(315576000000L, -999999999)) must be(false)
+        Duration.isValid(Duration(0, 1000000000)) must be(false)
+        Duration.isValid(Duration(0, 999999999)) must be(true)
+        Duration.isValid(Duration(0, 0)) must be(true)
+        Duration.isValid(Duration(0, -999999999)) must be(true)
+        Duration.isValid(Duration(0, -1000000000)) must be(false)
+        Duration.isValid(Duration(-315576000000L, 999999999)) must be(false)
+        Duration.isValid(Duration(-315576000000L, 0)) must be(true)
+        Duration.isValid(Duration(-315576000000L, -999999999)) must be(true)
+        Duration.isValid(Duration(-315576000001L, 0)) must be(false)
+    }
 }

--- a/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
@@ -20,7 +20,8 @@ trait DurationCompanionMethods {
 
   final def isValid(seconds: Long, nanos: Int): Boolean =
     (seconds >= DURATION_SECONDS_MIN) && (seconds <= DURATION_SECONDS_MAX) &&
-      (nanos >= 0) && (nanos < NANOS_PER_SECOND)
+    (nanos > -NANOS_PER_SECOND) && (nanos < NANOS_PER_SECOND) &&
+    (math.signum(seconds) * math.signum(nanos) != -1)
 
   final def isValid(duration: Duration): Boolean =
     isValid(duration.seconds, duration.nanos)

--- a/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
@@ -20,8 +20,8 @@ trait DurationCompanionMethods {
 
   final def isValid(seconds: Long, nanos: Int): Boolean =
     (seconds >= DURATION_SECONDS_MIN) && (seconds <= DURATION_SECONDS_MAX) &&
-    (nanos > -NANOS_PER_SECOND) && (nanos < NANOS_PER_SECOND) &&
-    (math.signum(seconds) * math.signum(nanos) != -1)
+      (nanos > -NANOS_PER_SECOND) && (nanos < NANOS_PER_SECOND) &&
+      (math.signum(seconds) * math.signum(nanos) != -1)
 
   final def isValid(duration: Duration): Boolean =
     isValid(duration.seconds, duration.nanos)


### PR DESCRIPTION
Fix #1068

> Note that if we allow negative nanos, the Duration would have to be normalized before being compared for ordering. There are reference implementation here: https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/main/java/com/google/protobuf/util/TimeUtil.java and https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/main/java/com/google/protobuf/util/Durations.java

@thesamet 
Thanks for your comment.
I think that validator does not need to call normalizer just as `Durations.isValid` does not call `TimeUtil.normalizedDuration` in Durations.java. Normalizer is required by math operators like `Durations.add` and `Durations.subtract`.
Although, I want math operators for Duration and Timestamp. I'm wondering if creating another pull request to implement them as protobuf-java-util wrapper.