### PR TITLE
Arithmetic operations for Timestamp and Duration

### DIFF
--- a/e2e/src/test/scalajvm/TimestampsSpec.scala
+++ b/e2e/src/test/scalajvm/TimestampsSpec.scala
@@ -6,52 +6,53 @@ import com.google.protobuf.timestamp.Timestamp
 import com.google.protobuf.duration.Duration
 
 class TimestampsSpec extends AnyFlatSpec with Matchers {
-    "Timestamps and Duration" should "have implicit ordering" in {
-        implicitly[Ordering[Timestamp]]
-        implicitly[Ordering[Duration]]
-    }
-    "Timestamps and Duration" should "be convertible for their java.time counterparts via implicit conversions" in {
-        import scalapb.TimestampConverters._
-        import scalapb.DurationConverters._
+  "Timestamps and Duration" should "have implicit ordering" in {
+    implicitly[Ordering[Timestamp]]
+    implicitly[Ordering[Duration]]
+  }
 
-        val t1: Instant = Instant.parse("2018-11-30T18:35:24.123Z")
-        val t2: Instant = Instant.parse("2018-11-30T18:35:25.456Z")
+  "Timestamps and Duration" should "be convertible for their java.time counterparts via implicit conversions" in {
+    import scalapb.TimestampConverters._
+    import scalapb.DurationConverters._
 
-        val timestamp: Timestamp = t1
-        timestamp must be(Timestamp(1543602924, 123000000))
-        (timestamp: Instant) must be(t1)
+    val t1: Instant = Instant.parse("2018-11-30T18:35:24.123Z")
+    val t2: Instant = Instant.parse("2018-11-30T18:35:25.456Z")
 
-        val duration: Duration = jtDuration.between(t1, t2)
-        duration must be(Duration(1, 333000000))
-        (duration: jtDuration) must be(jtDuration.between(t1, t2))
-    }
+    val timestamp: Timestamp = t1
+    timestamp must be(Timestamp(1543602924, 123000000))
+    (timestamp: Instant) must be(t1)
 
-    "Timestamps and Duration" can "be convertible for their java.time counterparts via helpers" in {
-        val t1: Instant = Instant.parse("2018-11-30T18:35:24.123Z")
-        val t2: Instant = Instant.parse("2018-11-30T18:35:25.456Z")
+    val duration: Duration = jtDuration.between(t1, t2)
+    duration must be(Duration(1, 333000000))
+    (duration: jtDuration) must be(jtDuration.between(t1, t2))
+  }
 
-        val timestamp: Timestamp = Timestamp(t1)
-        timestamp must be(Timestamp(1543602924, 123000000))
-        timestamp.asJavaInstant must be(t1)
+  "Timestamps and Duration" can "be convertible for their java.time counterparts via helpers" in {
+    val t1: Instant = Instant.parse("2018-11-30T18:35:24.123Z")
+    val t2: Instant = Instant.parse("2018-11-30T18:35:25.456Z")
 
-        val duration: Duration = Duration(jtDuration.between(t1, t2))
-        duration must be(Duration(1, 333000000))
-        duration.asJavaDuration must be(jtDuration.between(t1, t2))
-    }
+    val timestamp: Timestamp = Timestamp(t1)
+    timestamp must be(Timestamp(1543602924, 123000000))
+    timestamp.asJavaInstant must be(t1)
 
-    "Durations" should "be valid when their seconds and nanos are in defined range and have same sign" in {
-        Duration.isValid(Duration(315576000001L, 0)) must be(false)
-        Duration.isValid(Duration(315576000000L, 999999999)) must be(true)
-        Duration.isValid(Duration(315576000000L, 0)) must be(true)
-        Duration.isValid(Duration(315576000000L, -999999999)) must be(false)
-        Duration.isValid(Duration(0, 1000000000)) must be(false)
-        Duration.isValid(Duration(0, 999999999)) must be(true)
-        Duration.isValid(Duration(0, 0)) must be(true)
-        Duration.isValid(Duration(0, -999999999)) must be(true)
-        Duration.isValid(Duration(0, -1000000000)) must be(false)
-        Duration.isValid(Duration(-315576000000L, 999999999)) must be(false)
-        Duration.isValid(Duration(-315576000000L, 0)) must be(true)
-        Duration.isValid(Duration(-315576000000L, -999999999)) must be(true)
-        Duration.isValid(Duration(-315576000001L, 0)) must be(false)
-    }
+    val duration: Duration = Duration(jtDuration.between(t1, t2))
+    duration must be(Duration(1, 333000000))
+    duration.asJavaDuration must be(jtDuration.between(t1, t2))
+  }
+
+  "Durations" should "be valid when their seconds and nanos are in defined range and have same sign" in {
+    Duration.isValid(Duration(315576000001L, 0)) must be(false)
+    Duration.isValid(Duration(315576000000L, 999999999)) must be(true)
+    Duration.isValid(Duration(315576000000L, 0)) must be(true)
+    Duration.isValid(Duration(315576000000L, -999999999)) must be(false)
+    Duration.isValid(Duration(0, 1000000000)) must be(false)
+    Duration.isValid(Duration(0, 999999999)) must be(true)
+    Duration.isValid(Duration(0, 0)) must be(true)
+    Duration.isValid(Duration(0, -999999999)) must be(true)
+    Duration.isValid(Duration(0, -1000000000)) must be(false)
+    Duration.isValid(Duration(-315576000000L, 999999999)) must be(false)
+    Duration.isValid(Duration(-315576000000L, 0)) must be(true)
+    Duration.isValid(Duration(-315576000000L, -999999999)) must be(true)
+    Duration.isValid(Duration(-315576000001L, 0)) must be(false)
+  }
 }

--- a/e2e/src/test/scalajvm/TimestampsSpec.scala
+++ b/e2e/src/test/scalajvm/TimestampsSpec.scala
@@ -40,6 +40,26 @@ class TimestampsSpec extends AnyFlatSpec with Matchers {
     duration.asJavaDuration must be(jtDuration.between(t1, t2))
   }
 
+  "Timestamps" should "be subtracted by another timestamp" in {
+    import scalapb.TimestampConverters._
+    import scalapb.implicits.TimestampOps
+
+    val t1: Timestamp = Instant.parse("0001-01-01T00:00:00.000000000Z")
+    val t2: Timestamp = Instant.parse("9999-12-31T23:59:59.999999999Z")
+    t2 - t1 must be(Duration(315537897599L, 999999999))
+    t1 - t2 must be(Duration(-315537897599L, -999999999))
+  }
+
+  "Timestamps" should "be added or subtracted by a duration" in {
+    import scalapb.implicits.TimestampOps
+
+    Timestamp(123, 456789000) + Duration(987, 654321000) must be(Timestamp(1111, 111110000))
+    intercept[IllegalArgumentException](Timestamp(200000000000L, 1) + Duration(200000000000L, 2))
+
+    Timestamp(987, 654321000) - Duration(1111, 111110000) must be(Timestamp(-124, 543211000))
+    intercept[IllegalArgumentException](Timestamp(-200000000000L, 1) - Duration(200000000000L, 2))
+  }
+
   "Durations" should "be valid when their seconds and nanos are in defined range and have same sign" in {
     Duration.isValid(Duration(315576000001L, 0)) must be(false)
     Duration.isValid(Duration(315576000000L, 999999999)) must be(true)
@@ -54,5 +74,29 @@ class TimestampsSpec extends AnyFlatSpec with Matchers {
     Duration.isValid(Duration(-315576000000L, 0)) must be(true)
     Duration.isValid(Duration(-315576000000L, -999999999)) must be(true)
     Duration.isValid(Duration(-315576000001L, 0)) must be(false)
+  }
+
+  "Durations" should "be added, subtracted, or divided by another duration" in {
+    import scalapb.implicits.DurationOps
+
+    Duration(13, 579000000) + Duration(24, 680000000) must be(Duration(38, 259000000))
+    intercept[IllegalArgumentException](Duration(315576000000L, 999999999) + Duration(0, 1))
+
+    Duration(-38, -259000000) - Duration(-13, -579000000) must be(Duration(-24, -680000000))
+    intercept[IllegalArgumentException](Duration(315575999999L, 999999999) - Duration(-1, -1))
+
+    Duration(1, 0) / Duration(2, 500000000) must be(0.4 +- 1e-6)
+    intercept[IllegalArgumentException](Duration(1, 2) / Duration(0, 0))
+  }
+
+  "Durations" should "be multiplied or divided by a double precision floating point number" in {
+    import scalapb.implicits.DurationOps
+
+    Duration(111, 111000001) * 2.3 must be(Duration(255, 555300002))
+    intercept[IllegalArgumentException](Duration(1000000, 10000) * -315576.0)
+
+    Duration(-255, -555300002) / -2.3 must be(Duration(111, 111000001))
+    intercept[IllegalArgumentException](Duration(-100000000000L, 0) / 0.3)
+    intercept[IllegalArgumentException](Duration(1, 2) / 0.0)
   }
 }

--- a/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/DurationCompanionMethods.scala
@@ -31,6 +31,65 @@ trait DurationCompanionMethods {
     duration
   }
 
+  final def normalizedDuration(seconds: Long, nanos: Int): Duration = {
+    var s = seconds
+    var n = nanos
+    if (n <= -NANOS_PER_SECOND || n >= NANOS_PER_SECOND) {
+      s = Math.addExact(s, n / NANOS_PER_SECOND)
+      n = (n % NANOS_PER_SECOND).toInt
+    }
+    if (s > 0 && n < 0) {
+      s = s - 1                        // no overflow since positive seconds is decremented
+      n = (n + NANOS_PER_SECOND).toInt // no overflow since negative nanos is added
+    } else if (s < 0 && n > 0) {
+      s = s + 1                        // no overflow since positive seconds is incremented
+      n = (n - NANOS_PER_SECOND).toInt // no overflow since positive nanos is subtracted
+    }
+    checkValid(Duration(s, n))
+  }
+
+  final def fromSecondsDouble(seconds: Double): Duration =
+    normalizedDuration(seconds.toLong, math.round((seconds % 1) * NANOS_PER_SECOND).toInt)
+
+  final def toSecondsDouble(duration: Duration): Double =
+    duration.seconds + duration.nanos.toDouble / NANOS_PER_SECOND
+
+  final def add(d1: Duration, d2: Duration): Duration = {
+    checkValid(d1)
+    checkValid(d2)
+    normalizedDuration(
+      Math.addExact(d1.seconds, d2.seconds),
+      Math.addExact(d1.nanos, d2.nanos)
+    )
+  }
+
+  final def subtract(d1: Duration, d2: Duration): Duration = {
+    checkValid(d1)
+    checkValid(d2)
+    normalizedDuration(
+      Math.subtractExact(d1.seconds, d2.seconds),
+      Math.subtractExact(d1.nanos, d2.nanos)
+    )
+  }
+
+  final def divide(d1: Duration, d2: Duration): Double = {
+    checkValid(d1)
+    checkValid(d2)
+    require(d2.seconds != 0 || d2.nanos != 0, "/ by zero duration")
+    toSecondsDouble(d1) / toSecondsDouble(d2)
+  }
+
+  final def multiply(duration: Duration, multiplier: Double): Duration = {
+    checkValid(duration)
+    fromSecondsDouble(toSecondsDouble(duration) * multiplier)
+  }
+
+  final def divide(duration: Duration, divider: Double): Duration = {
+    checkValid(duration)
+    require(divider != 0.0, "/ by zero")
+    fromSecondsDouble(toSecondsDouble(duration) / divider)
+  }
+
   final val DURATION_SECONDS_MIN: Long = -315576000000L
   final val DURATION_SECONDS_MAX: Long = 315576000000L
 }

--- a/scalapb-runtime/src/main/scala/scalapb/TimestampCompanionMethods.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/TimestampCompanionMethods.scala
@@ -2,6 +2,7 @@ package scalapb
 
 import java.time.Instant
 
+import com.google.protobuf.duration.Duration
 import com.google.protobuf.timestamp.Timestamp
 
 trait TimestampCompanionMethods {
@@ -27,6 +28,47 @@ trait TimestampCompanionMethods {
   final def checkValid(timestamp: Timestamp): Timestamp = {
     require(isValid(timestamp), s"Timestamp ${timestamp} is not valid.")
     timestamp
+  }
+
+  final def normalizedTimestamp(seconds: Long, nanos: Int): Timestamp = {
+    var s = seconds
+    var n = nanos
+    if (n <= -NANOS_PER_SECOND || n >= NANOS_PER_SECOND) {
+      s = Math.addExact(s, n / NANOS_PER_SECOND)
+      n = (n % NANOS_PER_SECOND).toInt
+    }
+    if (n < 0) {
+      s = Math.subtractExact(s, 1)
+      n = (n + NANOS_PER_SECOND).toInt // no overflow since negative nanos is added
+    }
+    checkValid(Timestamp(s, n))
+  }
+
+  final def between(from: Timestamp, to: Timestamp): Duration = {
+    checkValid(from)
+    checkValid(to)
+    Duration.normalizedDuration(
+      Math.subtractExact(to.seconds, from.seconds),
+      Math.subtractExact(to.nanos, from.nanos)
+    )
+  }
+
+  final def add(start: Timestamp, length: Duration): Timestamp = {
+    checkValid(start)
+    Duration.checkValid(length)
+    normalizedTimestamp(
+      Math.addExact(start.seconds, length.seconds),
+      Math.addExact(start.nanos, length.nanos)
+    )
+  }
+
+  final def subtract(start: Timestamp, length: Duration): Timestamp = {
+    checkValid(start)
+    Duration.checkValid(length)
+    normalizedTimestamp(
+      Math.subtractExact(start.seconds, length.seconds),
+      Math.subtractExact(start.nanos, length.nanos)
+    )
   }
 
   final val TIMESTAMP_SECONDS_MIN: Long = -62135596800L

--- a/scalapb-runtime/src/main/scala/scalapb/implicits.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/implicits.scala
@@ -1,0 +1,20 @@
+package scalapb
+
+import com.google.protobuf.duration.Duration
+import com.google.protobuf.timestamp.Timestamp
+
+object implicits {
+  implicit class DurationOps(val value: Duration) extends AnyVal {
+    def +(that: Duration): Duration = Duration.add(value, that)
+    def -(that: Duration): Duration = Duration.subtract(value, that)
+    def /(that: Duration): Double   = Duration.divide(value, that)
+    def *(that: Double): Duration   = Duration.multiply(value, that)
+    def /(that: Double): Duration   = Duration.divide(value, that)
+  }
+
+  implicit class TimestampOps(val value: Timestamp) extends AnyVal {
+    def -(that: Timestamp): Duration = Timestamp.between(that, value)
+    def +(that: Duration): Timestamp = Timestamp.add(value, that)
+    def -(that: Duration): Timestamp = Timestamp.subtract(value, that)
+  }
+}


### PR DESCRIPTION
I use a lot of time arithmetic in my microservice. I would like to port this implementation to ScalaPB.
8 operations are implemented.

- Duration + Duration = Duration
- Duration - Duration = Duration
- Duration / Duration = Double
- Duration * Double = Duration
- Duration / Double = Duration
- Timestamp - Timestamp = Duration
- Timestamp + Duration = Timestamp
- Timestamp - Duration = Timestamp

The main functions, such as `Timestamp.normalizedTimestamp` and `Timestamp.between`, mimic [com/google/protobuf/util/Durations.java](https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/main/java/com/google/protobuf/util/Durations.java) and [com/google/protobuf/util/Timestamps.java](https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/main/java/com/google/protobuf/util/Timestamps.java).
These use `java.lang.Math.addExact` instead of `com.google.common.math.LongMath.checkedAdd` in Guava.

I tried to implement infix operators `+`, `-`, `*` and `/` in `DurationMethods` and `TimestampMethods`, but failed.

```DurationMethods.scala
trait DurationMethods {
  // ...
  def +(that: Duration): Duration = Duration.add(this, that)
}
```

```
[error]  found   : scalapb.DurationMethods
[error]  required: com.google.protobuf.duration.Duration
[error]   def +(that: Duration): Duration = Duration.add(this, that)
[error]                                                  ^
```

Therefore, I create implicit classes `DurationOps` and `TimestampOps`.