### PR TITLE
Tolerate a message called `Unit` when generating gRPC services. 

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -18,7 +18,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       case StreamType.ClientStreaming =>
         s"(responseObserver: ${observer(method.outputType.scalaType)}): ${observer(method.inputType.scalaType)}"
       case StreamType.ServerStreaming =>
-        s"(request: ${method.inputType.scalaType}, responseObserver: ${observer(method.outputType.scalaType)}): Unit"
+        s"(request: ${method.inputType.scalaType}, responseObserver: ${observer(method.outputType.scalaType)}): _root_.scala.Unit"
       case StreamType.Bidirectional =>
         s"(responseObserver: ${observer(method.outputType.scalaType)}): ${observer(method.inputType.scalaType)}"
     })
@@ -208,7 +208,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
             val serverMethod =
               s"$serverCalls.UnaryMethod[${method.inputType.scalaType}, ${method.outputType.scalaType}]"
             p.add(s"""$call(new $serverMethod {
-                     |  override def invoke(request: ${method.inputType.scalaType}, observer: $streamObserver[${method.outputType.scalaType}]): Unit =
+                     |  override def invoke(request: ${method.inputType.scalaType}, observer: $streamObserver[${method.outputType.scalaType}]): _root_.scala.Unit =
                      |    $serviceImpl.${method.name}(request).onComplete(scalapb.grpc.Grpc.completeObserver(observer))(
                      |      $executionContext)
                      |}))""".stripMargin)
@@ -216,7 +216,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
             val serverMethod =
               s"$serverCalls.ServerStreamingMethod[${method.inputType.scalaType}, ${method.outputType.scalaType}]"
             p.add(s"""$call(new $serverMethod {
-                     |  override def invoke(request: ${method.inputType.scalaType}, observer: $streamObserver[${method.outputType.scalaType}]): Unit =
+                     |  override def invoke(request: ${method.inputType.scalaType}, observer: $streamObserver[${method.outputType.scalaType}]): _root_.scala.Unit =
                      |    $serviceImpl.${method.name}(request, observer)
                      |}))""".stripMargin)
           case _ =>

--- a/e2e-grpc/src/main/protobuf/service.proto
+++ b/e2e-grpc/src/main/protobuf/service.proto
@@ -47,6 +47,9 @@ message SealedResponse {
     }
 }
 
+// https://github.com/scalapb/ScalaPB/issues/1126
+message Unit {}
+
 extend google.protobuf.MethodOptions {
     string custom_option = 50001;
 }
@@ -57,7 +60,7 @@ extend google.protobuf.ServiceOptions {
 
 service Service1 {
   option (custom_service_option) = "custom_service_value";
-  
+
   // Computes string length
   rpc UnaryStringLength(Req1) returns (Res1) {}
 

--- a/e2e-grpc/src/main/scala/com/thesamet/pb/Service1JavaImpl.scala
+++ b/e2e-grpc/src/main/scala/com/thesamet/pb/Service1JavaImpl.scala
@@ -2,7 +2,7 @@ package com.thesamet.pb
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.thesamet.proto.e2e.Service._
+import com.thesamet.proto.e2e.Service.{Unit=>_, _}
 import com.thesamet.proto.e2e.Service1Grpc._
 import io.grpc.stub.StreamObserver
 

--- a/e2e-grpc/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
+++ b/e2e-grpc/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.thesamet.proto.e2e.service.SealedRequest
 import com.thesamet.proto.e2e.service.Service1Grpc.Service1
-import com.thesamet.proto.e2e.service._
+import com.thesamet.proto.e2e.service.{Unit=>_, _}
 import io.grpc.stub.StreamObserver
 
 import scala.concurrent.Future


### PR DESCRIPTION
Fixes #1126. The addition of `message Unit {}` to `src/main/protobuf/service.proto` surfaces the issue. You can revert the changes to  `GrpcServicePrinter` to see the error.