### PR TITLE
Add HasBuilder, improves binary compatibility between 0.10.x and 0.11.x

### DIFF
--- a/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -241,6 +241,33 @@ trait GeneratedMessageCompanion[A <: GeneratedMessage] {
   def defaultInstance: A
 }
 
+/** This trait is not used in ScalaPB 0.11.x, but having it present on the classpath
+  * improves binary compatibility with 0.10.x: it allows using code generated with
+  * 0.10.x with newer versions of the runtime in some cases.
+  *
+  * This class is included here to ease updates from 0.10.x to 0.11.x, but this is
+  * not guaranteed to keep working. You are encouraged to upgrade to 0.11.x ASAP.
+  */
+@deprecated(
+  "No longer used in newly-generated ScalaPB code, but might be referenced in code generated with ScalaPB 0.10.x",
+  "0.11.x"
+)
+trait HasBuilder[A <: GeneratedMessage] {
+  self: GeneratedMessageCompanion[A] =>
+
+  /** This method is never implemented by newly-generated ScalaPB code anymore, but might
+    * be present in code generated with ScalaPB 0.10.x
+    */
+  @deprecated("unused for new code, only remains for binary compatibility", "0.11.x")
+  def newBuilder: MessageBuilder[A]
+
+  /** This method should never be referenced by newly-generated ScalaPB code anymore, but might
+    * be called from code generated with ScalaPB 0.10.x
+    */
+  @deprecated("unused for new code, only remains for binary compatibility", "0.11.x")
+  final def parseFrom(input: CodedInputStream): A = newBuilder.merge(input).result()
+}
+
 abstract class GeneratedFileObject {
   def scalaDescriptor: _root_.scalapb.descriptors.FileDescriptor
 

--- a/scalapb-runtime/src/main/scala/scalapb/MessageBuilder.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/MessageBuilder.scala
@@ -2,12 +2,12 @@ package scalapb
 
 import com.google.protobuf.CodedInputStream
 
-/** Allows building an instance of a message A
+/** Kept for binary compatibility between 0.11.x and 0.10.x
   *
-  * The code generator will create a class that extends MessageBuilder for each message.
-  * It generally contains a `var` for each optional and required field, and a
-  * [scala.collection.mutable.Builder] for each repeated field.
+  * On 0.10.x, the code generator would create a class that extended MessageBuilder
+  * for each message.
   */
+@deprecated("Kept for binary compatibility", "0.11.x")
 abstract class MessageBuilder[A] {
   def merge(input: CodedInputStream): this.type
 
@@ -17,6 +17,7 @@ abstract class MessageBuilder[A] {
   def result(): A
 }
 
+@deprecated("Kept for binary compatibility", "0.11.x")
 trait MessageBuilderCompanion[A, Builder] {
   def apply(a: A): Builder
 }


### PR DESCRIPTION
On the 0.10.x branch, 9a0561901eb7d16827a837f7d22b283bd3cf9daf
introduced a `HasBuilder` trait.

This trait was not introduced to the 0.11.x branch. Because of this,
code generated with 0.10.x of the generator cannot be ran with
0.11.x of the runtime.

Of course we cannot expect 0.10.x to be fully binary compatible with
0.11.x . However, some testing suggests that just making this class
and the `MessageBuilder` interface available on the classpath allows
using the 0.10.x-generated classes with the 0.11.x runtime in simple
cases - allowing for a smoother upgrade path to 0.11.x.

We should stronly encourage people to move to 0.11.x, but having a
ScalaPB release that supports this gives a smoother upgrade path.

Fixes #1153