### PR TITLE
Update docs: fix link to GeneratedMessageCompanion.scala

### DIFF
--- a/docs/src/main/markdown/generated-code.md
+++ b/docs/src/main/markdown/generated-code.md
@@ -76,7 +76,7 @@ object Person extends GeneratedMessageCompanion[Person] {
 The case class contains various methods for serialization, and the companion
 object contains method for parsing. [See the source code for
 `GeneratedMessage` and
-`GeneratedMessageCompanion`](https://github.com/scalapb/ScalaPB/blob/master/scalapb-runtime/shared/src/main/scala/scalapb/GeneratedMessageCompanion.scala)
+`GeneratedMessageCompanion`](https://github.com/scalapb/ScalaPB/blob/master/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala)
 to see what methods are available
 
 ### Building New Messages


### PR DESCRIPTION
The file has moved with [this commit](https://github.com/scalapb/ScalaPB/commit/3473981f6ebda0f872a6040d2ba157a800ebb4da#diff-a56f15520046098f5c39fda3c940c9e92de4953c330e554f8e4029311be422fa)