### PR TITLE
Add `export` to list of reserved words (scala 3).

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -1077,6 +1077,7 @@ object DescriptorImplicits {
     "do",
     "else",
     "enum",
+    "export",
     "extends",
     "false",
     "final",
@@ -1089,6 +1090,7 @@ object DescriptorImplicits {
     "lazy",
     "macro",
     "match",
+    "ne",
     "new",
     "null",
     "object",
@@ -1110,9 +1112,7 @@ object DescriptorImplicits {
     "var",
     "while",
     "with",
-    "yield",
-    "ne",
-    "export"
+    "yield"
   )
 
   def primitiveWrapperType(messageType: Descriptor): Option[String] =

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -1111,7 +1111,8 @@ object DescriptorImplicits {
     "while",
     "with",
     "yield",
-    "ne"
+    "ne",
+    "export"
   )
 
   def primitiveWrapperType(messageType: Descriptor): Option[String] =


### PR DESCRIPTION
To solve error with the new scala 3 [keyword](https://dotty.epfl.ch/docs/reference/other-new-features/export.html)
```
[error]    |    an identifier expected, but 'export' found
```