### PR TITLE
remove Serializable from types inferred across companions

### DIFF
--- a/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/GeneratedMessageCompanion.scala
@@ -43,7 +43,7 @@ trait UnrecognizedEnum extends GeneratedEnum {
     companion.scalaDescriptor.findValueByNumberCreatingIfUnknown(value)
 }
 
-trait GeneratedEnumCompanion[A <: GeneratedEnum] {
+trait GeneratedEnumCompanion[A <: GeneratedEnum] extends Serializable {
   type ValueType = A
   def fromValue(value: Int): A
   def fromName(name: String): Option[A] = values.find(_.name == name)
@@ -160,7 +160,7 @@ trait JavaProtoSupport[ScalaPB, JavaPB] extends Any {
   def toJavaProto(scalaProto: ScalaPB): JavaPB
 }
 
-trait GeneratedMessageCompanion[A <: GeneratedMessage] {
+trait GeneratedMessageCompanion[A <: GeneratedMessage] extends Serializable {
   self =>
   type ValueType = A
 


### PR DESCRIPTION
Follows https://github.com/scalapb/ScalaPB/pull/984, which was not enough for the previous use-case.

On master:
```
[wartremover:Serializable] Inferred type containing Serializable: scalapb.GeneratedMessage{def companion: java.io.Serializable}
[error]         Seq(
[error]         ^
```