### PR TITLE
make TypeMapper serializable

### DIFF
--- a/scalapb-runtime/src/main/scala/scalapb/TypeMapper.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/TypeMapper.scala
@@ -11,7 +11,7 @@ import com.google.protobuf.ByteString
     Alternatively you can import this implicit using file-level Scala imports (see documentation)
     """
 )
-abstract class TypeMapper[BaseType, CustomType] {
+abstract class TypeMapper[BaseType, CustomType] extends Serializable {
   def toCustom(base: BaseType): CustomType
   def toBase(custom: CustomType): BaseType
 

--- a/scalapb-runtime/src/test/scala/scalapb/TypeMapperSpec.scala
+++ b/scalapb-runtime/src/test/scala/scalapb/TypeMapperSpec.scala
@@ -1,0 +1,16 @@
+package scalapb
+
+import munit.FunSuite
+
+import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+
+class TypeMapperSpec extends FunSuite {
+  test("serialize") {
+    val mapper = TypeMapper[String, Int](_.toInt)(_.toString)
+    val buffer = new ByteArrayOutputStream()
+    val stream = new ObjectOutputStream(buffer)
+    stream.writeObject(mapper)
+    stream.close()
+    assert(buffer.toByteArray.length > 0, "TypeMapper is not serializable")
+  }
+}


### PR DESCRIPTION
I'm a maintainer of https://github.com/findify/flink-protobuf project, which tries to make a native protobuf connector for Apache Flink. And Flink itself, as a distributed computing framework, uses a Apache Spark inspired way of shipping code to compute nodes:
* it builds a job graph.
* the job graph is then serialized (not only the data, but also the bytecode itself) and sent to nodes.
* shipped job graph also contains all the code needed for data serialization.

The problem starts when we have oneof-encoded messages, which in ScalaPB are generated as sealed traits. To do a conversion from the message to the concrete type member, there is a TypeMapper class to perform the mapping. 

For example, given the message:
```proto
message Foo1 {
    required int32 value = 1;
}

message Bar1 {
    required string value = 1;
}

message SealedOptional {
    oneof sealed_value_optional {
        Foo1 foo = 1;
        Bar1 bar = 2;
    }
}
```

ScalaPB generates the following code snippet:
```scala
sealed trait SealedOptional {
  type MessageType = io.findify.flinkprotobuf.scala.SealedOptionalMessage
  final def asMessage: io.findify.flinkprotobuf.scala.SealedOptionalMessage = io.findify.flinkprotobuf.scala.SealedOptional.SealedOptionalTypeMapper.toBase(Some(this))
}

object SealedOptional {
  implicit val SealedOptionalTypeMapper: _root_.scalapb.TypeMapper[io.findify.flinkprotobuf.scala.SealedOptionalMessage, _root_.scala.Option[io.findify.flinkprotobuf.scala.SealedOptional]] = new _root_.scalapb.TypeMapper[io.findify.flinkprotobuf.scala.SealedOptionalMessage, _root_.scala.Option[io.findify.flinkprotobuf.scala.SealedOptional]] {
    override def toCustom(__base: io.findify.flinkprotobuf.scala.SealedOptionalMessage): _root_.scala.Option[io.findify.flinkprotobuf.scala.SealedOptional] = __base.sealedValueOptional match {
      case __v: io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Foo => Some(__v.value)
      case __v: io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Bar => Some(__v.value)
      case io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Empty => None
    }
    override def toBase(__custom: _root_.scala.Option[io.findify.flinkprotobuf.scala.SealedOptional]): io.findify.flinkprotobuf.scala.SealedOptionalMessage = io.findify.flinkprotobuf.scala.SealedOptionalMessage(__custom match {
      case Some(__v: io.findify.flinkprotobuf.scala.Foo1) => io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Foo(__v)
      case Some(__v: io.findify.flinkprotobuf.scala.Bar1) => io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Bar(__v)
      case None => io.findify.flinkprotobuf.scala.SealedOptionalMessage.SealedValueOptional.Empty
    })
  }
}

```

I would like to use this type mapper in my code, but it cannot be serialized as it is not extending the `java.io.Serializable` type, so Flink throws `NonSerializableExceptions` to me. Adding the ` extends Serializable ` solves the issue (at least on my local build).

So in this PR:
* one-line change to add ` extends Serializable` to `TypeMapper`
* a test to validate that the dummy TypeMapper can be written to `ObjectOutputStream`