### PR TITLE
Scala 3: add explicit type to avoid inferred GeneratedMessageCompanion

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -1396,7 +1396,7 @@ class ProtobufGenerator(
       .when(params.asciiFormatToString)(
         _.add("override def toString: _root_.scala.Predef.String = toProtoString")
       )
-      .add(s"def companion = ${fullName}")
+      .add(s"def companion: ${fullName}.type = ${fullName}")
       .when(message.isSealedOneofType) { fp =>
         val scalaType = message.sealedOneofScalaType
         val name      = message.sealedOneofTraitScalaType.name

--- a/docs/src/main/scala/com/thesamet/docs/json/MyContainer.scala
+++ b/docs/src/main/scala/com/thesamet/docs/json/MyContainer.scala
@@ -55,7 +55,7 @@ final case class MyContainer(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.thesamet.docs.json.MyContainer
+    def companion: com.thesamet.docs.json.MyContainer.type = com.thesamet.docs.json.MyContainer
     // @@protoc_insertion_point(GeneratedMessage[com.thesamet.docs.MyContainer])
 }
 

--- a/docs/src/main/scala/com/thesamet/docs/json/MyMessage.scala
+++ b/docs/src/main/scala/com/thesamet/docs/json/MyMessage.scala
@@ -59,7 +59,7 @@ final case class MyMessage(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.thesamet.docs.json.MyMessage
+    def companion: com.thesamet.docs.json.MyMessage.type = com.thesamet.docs.json.MyMessage
     // @@protoc_insertion_point(GeneratedMessage[com.thesamet.docs.MyMessage])
 }
 

--- a/docs/src/main/scala/mytypes/duration/Duration.scala
+++ b/docs/src/main/scala/mytypes/duration/Duration.scala
@@ -59,7 +59,7 @@ final case class Duration(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = mytypes.duration.Duration
+    def companion: mytypes.duration.Duration.type = mytypes.duration.Duration
     // @@protoc_insertion_point(GeneratedMessage[mytypes.Duration])
 }
 

--- a/docs/src/main/scala/scalapb/docs/person/Person.scala
+++ b/docs/src/main/scala/scalapb/docs/person/Person.scala
@@ -96,7 +96,7 @@ final case class Person(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.docs.person.Person
+    def companion: scalapb.docs.person.Person.type = scalapb.docs.person.Person
     // @@protoc_insertion_point(GeneratedMessage[scalapb.docs.Person])
 }
 
@@ -292,7 +292,7 @@ object Person extends scalapb.GeneratedMessageCompanion[scalapb.docs.person.Pers
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.docs.person.Person.Address
+      def companion: scalapb.docs.person.Person.Address.type = scalapb.docs.person.Person.Address
       // @@protoc_insertion_point(GeneratedMessage[scalapb.docs.Person.Address])
   }
   

--- a/docs/src/main/scala/scalapb/perf/protos/Enum.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/Enum.scala
@@ -59,7 +59,7 @@ final case class Enum(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.Enum
+    def companion: scalapb.perf.protos.Enum.type = scalapb.perf.protos.Enum
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.Enum])
 }
 

--- a/docs/src/main/scala/scalapb/perf/protos/EnumVector.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/EnumVector.scala
@@ -64,7 +64,7 @@ final case class EnumVector(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.EnumVector
+    def companion: scalapb.perf.protos.EnumVector.type = scalapb.perf.protos.EnumVector
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.EnumVector])
 }
 

--- a/docs/src/main/scala/scalapb/perf/protos/IntVector.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/IntVector.scala
@@ -64,7 +64,7 @@ final case class IntVector(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.IntVector
+    def companion: scalapb.perf.protos.IntVector.type = scalapb.perf.protos.IntVector
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.IntVector])
 }
 

--- a/docs/src/main/scala/scalapb/perf/protos/MessageContainer.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/MessageContainer.scala
@@ -75,7 +75,7 @@ final case class MessageContainer(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.MessageContainer
+    def companion: scalapb.perf.protos.MessageContainer.type = scalapb.perf.protos.MessageContainer
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.MessageContainer])
 }
 

--- a/docs/src/main/scala/scalapb/perf/protos/SimpleMessage.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/SimpleMessage.scala
@@ -119,7 +119,7 @@ final case class SimpleMessage(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.SimpleMessage
+    def companion: scalapb.perf.protos.SimpleMessage.type = scalapb.perf.protos.SimpleMessage
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.SimpleMessage])
 }
 

--- a/docs/src/main/scala/scalapb/perf/protos/StringMessage.scala
+++ b/docs/src/main/scala/scalapb/perf/protos/StringMessage.scala
@@ -79,7 +79,7 @@ final case class StringMessage(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.perf.protos.StringMessage
+    def companion: scalapb.perf.protos.StringMessage.type = scalapb.perf.protos.StringMessage
     // @@protoc_insertion_point(GeneratedMessage[scalapb.perf.StringMessage])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/any/Any.scala
@@ -190,7 +190,7 @@ final case class Any(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.any.Any
+    def companion: com.google.protobuf.any.Any.type = com.google.protobuf.any.Any
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Any])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Api.scala
@@ -211,7 +211,7 @@ final case class Api(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Api
+    def companion: com.google.protobuf.api.Api.type = com.google.protobuf.api.Api
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Api])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Method.scala
@@ -193,7 +193,7 @@ final case class Method(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Method
+    def companion: com.google.protobuf.api.Method.type = com.google.protobuf.api.Method
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Method])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/api/Mixin.scala
@@ -164,7 +164,7 @@ final case class Mixin(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Mixin
+    def companion: com.google.protobuf.api.Mixin.type = com.google.protobuf.api.Mixin
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Mixin])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -127,7 +127,7 @@ final case class CodeGeneratorRequest(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.CodeGeneratorRequest
+    def companion: com.google.protobuf.compiler.plugin.CodeGeneratorRequest.type = com.google.protobuf.compiler.plugin.CodeGeneratorRequest
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorRequest])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -99,7 +99,7 @@ final case class CodeGeneratorResponse(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.CodeGeneratorResponse
+    def companion: com.google.protobuf.compiler.plugin.CodeGeneratorResponse.type = com.google.protobuf.compiler.plugin.CodeGeneratorResponse
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorResponse])
 }
 
@@ -334,7 +334,7 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File
+      def companion: com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File.type = com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorResponse.File])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/compiler/plugin/Version.scala
@@ -101,7 +101,7 @@ final case class Version(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.Version
+    def companion: com.google.protobuf.compiler.plugin.Version.type = com.google.protobuf.compiler.plugin.Version
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.Version])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -209,7 +209,7 @@ final case class DescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.DescriptorProto
+    def companion: com.google.protobuf.descriptor.DescriptorProto.type = com.google.protobuf.descriptor.DescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto])
 }
 
@@ -407,7 +407,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.DescriptorProto.ExtensionRange
+      def companion: com.google.protobuf.descriptor.DescriptorProto.ExtensionRange.type = com.google.protobuf.descriptor.DescriptorProto.ExtensionRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto.ExtensionRange])
   }
   
@@ -563,7 +563,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.DescriptorProto.ReservedRange
+      def companion: com.google.protobuf.descriptor.DescriptorProto.ReservedRange.type = com.google.protobuf.descriptor.DescriptorProto.ReservedRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto.ReservedRange])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -128,7 +128,7 @@ final case class EnumDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumDescriptorProto
+    def companion: com.google.protobuf.descriptor.EnumDescriptorProto.type = com.google.protobuf.descriptor.EnumDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumDescriptorProto])
 }
 
@@ -281,7 +281,7 @@ object EnumDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange
+      def companion: com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange.type = com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumDescriptorProto.EnumReservedRange])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumOptions.scala
@@ -95,7 +95,7 @@ final case class EnumOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumOptions
+    def companion: com.google.protobuf.descriptor.EnumOptions.type = com.google.protobuf.descriptor.EnumOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -85,7 +85,7 @@ final case class EnumValueDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumValueDescriptorProto
+    def companion: com.google.protobuf.descriptor.EnumValueDescriptorProto.type = com.google.protobuf.descriptor.EnumValueDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValueDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -78,7 +78,7 @@ final case class EnumValueOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumValueOptions
+    def companion: com.google.protobuf.descriptor.EnumValueOptions.type = com.google.protobuf.descriptor.EnumValueOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValueOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
@@ -59,7 +59,7 @@ final case class ExtensionRangeOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ExtensionRangeOptions
+    def companion: com.google.protobuf.descriptor.ExtensionRangeOptions.type = com.google.protobuf.descriptor.ExtensionRangeOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ExtensionRangeOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -246,7 +246,7 @@ final case class FieldDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FieldDescriptorProto
+    def companion: com.google.protobuf.descriptor.FieldDescriptorProto.type = com.google.protobuf.descriptor.FieldDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FieldOptions.scala
@@ -202,7 +202,7 @@ final case class FieldOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FieldOptions
+    def companion: com.google.protobuf.descriptor.FieldOptions.type = com.google.protobuf.descriptor.FieldOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -250,7 +250,7 @@ final case class FileDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileDescriptorProto
+    def companion: com.google.protobuf.descriptor.FileDescriptorProto.type = com.google.protobuf.descriptor.FileDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -59,7 +59,7 @@ final case class FileDescriptorSet(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileDescriptorSet
+    def companion: com.google.protobuf.descriptor.FileDescriptorSet.type = com.google.protobuf.descriptor.FileDescriptorSet
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileDescriptorSet])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/FileOptions.scala
@@ -417,7 +417,7 @@ final case class FileOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileOptions
+    def companion: com.google.protobuf.descriptor.FileOptions.type = com.google.protobuf.descriptor.FileOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -64,7 +64,7 @@ final case class GeneratedCodeInfo(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.GeneratedCodeInfo
+    def companion: com.google.protobuf.descriptor.GeneratedCodeInfo.type = com.google.protobuf.descriptor.GeneratedCodeInfo
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.GeneratedCodeInfo])
 }
 
@@ -231,7 +231,7 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation
+      def companion: com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation.type = com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.GeneratedCodeInfo.Annotation])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MessageOptions.scala
@@ -165,7 +165,7 @@ final case class MessageOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MessageOptions
+    def companion: com.google.protobuf.descriptor.MessageOptions.type = com.google.protobuf.descriptor.MessageOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MessageOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -135,7 +135,7 @@ final case class MethodDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MethodDescriptorProto
+    def companion: com.google.protobuf.descriptor.MethodDescriptorProto.type = com.google.protobuf.descriptor.MethodDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MethodDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/MethodOptions.scala
@@ -92,7 +92,7 @@ final case class MethodOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MethodOptions
+    def companion: com.google.protobuf.descriptor.MethodOptions.type = com.google.protobuf.descriptor.MethodOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MethodOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -71,7 +71,7 @@ final case class OneofDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.OneofDescriptorProto
+    def companion: com.google.protobuf.descriptor.OneofDescriptorProto.type = com.google.protobuf.descriptor.OneofDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.OneofDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/OneofOptions.scala
@@ -59,7 +59,7 @@ final case class OneofOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.OneofOptions
+    def companion: com.google.protobuf.descriptor.OneofOptions.type = com.google.protobuf.descriptor.OneofOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.OneofOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -88,7 +88,7 @@ final case class ServiceDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ServiceDescriptorProto
+    def companion: com.google.protobuf.descriptor.ServiceDescriptorProto.type = com.google.protobuf.descriptor.ServiceDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ServiceDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -78,7 +78,7 @@ final case class ServiceOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ServiceOptions
+    def companion: com.google.protobuf.descriptor.ServiceOptions.type = com.google.protobuf.descriptor.ServiceOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ServiceOptions])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -104,7 +104,7 @@ final case class SourceCodeInfo(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.SourceCodeInfo
+    def companion: com.google.protobuf.descriptor.SourceCodeInfo.type = com.google.protobuf.descriptor.SourceCodeInfo
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceCodeInfo])
 }
 
@@ -363,7 +363,7 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.SourceCodeInfo.Location
+      def companion: com.google.protobuf.descriptor.SourceCodeInfo.Location.type = com.google.protobuf.descriptor.SourceCodeInfo.Location
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceCodeInfo.Location])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -151,7 +151,7 @@ final case class UninterpretedOption(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.UninterpretedOption
+    def companion: com.google.protobuf.descriptor.UninterpretedOption.type = com.google.protobuf.descriptor.UninterpretedOption
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UninterpretedOption])
 }
 
@@ -308,7 +308,7 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.UninterpretedOption.NamePart
+      def companion: com.google.protobuf.descriptor.UninterpretedOption.NamePart.type = com.google.protobuf.descriptor.UninterpretedOption.NamePart
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UninterpretedOption.NamePart])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/duration/Duration.scala
@@ -150,7 +150,7 @@ final case class Duration(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.duration.Duration
+    def companion: com.google.protobuf.duration.Duration.type = com.google.protobuf.duration.Duration
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Duration])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/empty/Empty.scala
@@ -42,7 +42,7 @@ final case class Empty(
     def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = throw new MatchError(__fieldNumber)
     def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = throw new MatchError(__field)
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.empty.Empty
+    def companion: com.google.protobuf.empty.Empty.type = com.google.protobuf.empty.Empty
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Empty])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/field_mask/FieldMask.scala
@@ -257,7 +257,7 @@ final case class FieldMask(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.field_mask.FieldMask
+    def companion: com.google.protobuf.field_mask.FieldMask.type = com.google.protobuf.field_mask.FieldMask
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldMask])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/source_context/SourceContext.scala
@@ -66,7 +66,7 @@ final case class SourceContext(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.source_context.SourceContext
+    def companion: com.google.protobuf.source_context.SourceContext.type = com.google.protobuf.source_context.SourceContext
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceContext])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/ListValue.scala
@@ -63,7 +63,7 @@ final case class ListValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.ListValue
+    def companion: com.google.protobuf.struct.ListValue.type = com.google.protobuf.struct.ListValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ListValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/Struct.scala
@@ -68,7 +68,7 @@ final case class Struct(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.Struct
+    def companion: com.google.protobuf.struct.Struct.type = com.google.protobuf.struct.Struct
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Struct])
 }
 
@@ -191,7 +191,7 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.struct.Struct.FieldsEntry
+      def companion: com.google.protobuf.struct.Struct.FieldsEntry.type = com.google.protobuf.struct.Struct.FieldsEntry
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Struct.FieldsEntry])
   }
   

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/struct/Value.scala
@@ -125,7 +125,7 @@ final case class Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.Value
+    def companion: com.google.protobuf.struct.Value.type = com.google.protobuf.struct.Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Value])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/timestamp/Timestamp.scala
@@ -172,7 +172,7 @@ final case class Timestamp(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.timestamp.Timestamp
+    def companion: com.google.protobuf.timestamp.Timestamp.type = com.google.protobuf.timestamp.Timestamp
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Timestamp])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Enum.scala
@@ -142,7 +142,7 @@ final case class Enum(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Enum
+    def companion: com.google.protobuf.`type`.Enum.type = com.google.protobuf.`type`.Enum
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Enum])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/type/EnumValue.scala
@@ -105,7 +105,7 @@ final case class EnumValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.EnumValue
+    def companion: com.google.protobuf.`type`.EnumValue.type = com.google.protobuf.`type`.EnumValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Field.scala
@@ -261,7 +261,7 @@ final case class Field(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Field
+    def companion: com.google.protobuf.`type`.Field.type = com.google.protobuf.`type`.Field
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Field])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/type/OptionProto.scala
@@ -89,7 +89,7 @@ final case class OptionProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.OptionProto
+    def companion: com.google.protobuf.`type`.OptionProto.type = com.google.protobuf.`type`.OptionProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Option])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/type/Type.scala
@@ -159,7 +159,7 @@ final case class Type(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Type
+    def companion: com.google.protobuf.`type`.Type.type = com.google.protobuf.`type`.Type
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Type])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/BoolValue.scala
@@ -66,7 +66,7 @@ final case class BoolValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.BoolValue
+    def companion: com.google.protobuf.wrappers.BoolValue.type = com.google.protobuf.wrappers.BoolValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.BoolValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/BytesValue.scala
@@ -66,7 +66,7 @@ final case class BytesValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.BytesValue
+    def companion: com.google.protobuf.wrappers.BytesValue.type = com.google.protobuf.wrappers.BytesValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.BytesValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/DoubleValue.scala
@@ -66,7 +66,7 @@ final case class DoubleValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.DoubleValue
+    def companion: com.google.protobuf.wrappers.DoubleValue.type = com.google.protobuf.wrappers.DoubleValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DoubleValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/FloatValue.scala
@@ -66,7 +66,7 @@ final case class FloatValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.FloatValue
+    def companion: com.google.protobuf.wrappers.FloatValue.type = com.google.protobuf.wrappers.FloatValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FloatValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/Int32Value.scala
@@ -66,7 +66,7 @@ final case class Int32Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.Int32Value
+    def companion: com.google.protobuf.wrappers.Int32Value.type = com.google.protobuf.wrappers.Int32Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Int32Value])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/Int64Value.scala
@@ -66,7 +66,7 @@ final case class Int64Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.Int64Value
+    def companion: com.google.protobuf.wrappers.Int64Value.type = com.google.protobuf.wrappers.Int64Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Int64Value])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/StringValue.scala
@@ -66,7 +66,7 @@ final case class StringValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.StringValue
+    def companion: com.google.protobuf.wrappers.StringValue.type = com.google.protobuf.wrappers.StringValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.StringValue])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/UInt32Value.scala
@@ -66,7 +66,7 @@ final case class UInt32Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.UInt32Value
+    def companion: com.google.protobuf.wrappers.UInt32Value.type = com.google.protobuf.wrappers.UInt32Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UInt32Value])
 }
 

--- a/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/src/main/js-native/com/google/protobuf/wrappers/UInt64Value.scala
@@ -66,7 +66,7 @@ final case class UInt64Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.UInt64Value
+    def companion: com.google.protobuf.wrappers.UInt64Value.type = com.google.protobuf.wrappers.UInt64Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UInt64Value])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/Collection.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/Collection.scala
@@ -94,7 +94,7 @@ final case class Collection(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.Collection
+    def companion: scalapb.options.Collection.type = scalapb.options.Collection
     // @@protoc_insertion_point(GeneratedMessage[scalapb.Collection])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/EnumOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/EnumOptions.scala
@@ -91,7 +91,7 @@ final case class EnumOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.EnumOptions
+    def companion: scalapb.options.EnumOptions.type = scalapb.options.EnumOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.EnumOptions])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/EnumValueOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/EnumValueOptions.scala
@@ -73,7 +73,7 @@ final case class EnumValueOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.EnumValueOptions
+    def companion: scalapb.options.EnumValueOptions.type = scalapb.options.EnumValueOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.EnumValueOptions])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/FieldOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/FieldOptions.scala
@@ -201,7 +201,7 @@ final case class FieldOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.FieldOptions
+    def companion: scalapb.options.FieldOptions.type = scalapb.options.FieldOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.FieldOptions])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/FieldTransformation.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/FieldTransformation.scala
@@ -85,7 +85,7 @@ final case class FieldTransformation(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.FieldTransformation
+    def companion: scalapb.options.FieldTransformation.type = scalapb.options.FieldTransformation
     // @@protoc_insertion_point(GeneratedMessage[scalapb.FieldTransformation])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/MessageOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/MessageOptions.scala
@@ -176,7 +176,7 @@ final case class MessageOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.MessageOptions
+    def companion: scalapb.options.MessageOptions.type = scalapb.options.MessageOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.MessageOptions])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/OneofOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/OneofOptions.scala
@@ -73,7 +73,7 @@ final case class OneofOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.OneofOptions
+    def companion: scalapb.options.OneofOptions.type = scalapb.options.OneofOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.OneofOptions])
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/options/PreprocessorOutput.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/PreprocessorOutput.scala
@@ -56,7 +56,7 @@ final case class PreprocessorOutput(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.PreprocessorOutput
+    def companion: scalapb.options.PreprocessorOutput.type = scalapb.options.PreprocessorOutput
     // @@protoc_insertion_point(GeneratedMessage[scalapb.PreprocessorOutput])
 }
 
@@ -173,7 +173,7 @@ object PreprocessorOutput extends scalapb.GeneratedMessageCompanion[scalapb.opti
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.options.PreprocessorOutput.OptionsByFileEntry
+      def companion: scalapb.options.PreprocessorOutput.OptionsByFileEntry.type = scalapb.options.PreprocessorOutput.OptionsByFileEntry
       // @@protoc_insertion_point(GeneratedMessage[scalapb.PreprocessorOutput.OptionsByFileEntry])
   }
   

--- a/scalapb-runtime/src/main/scala/scalapb/options/ScalaPbOptions.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/options/ScalaPbOptions.scala
@@ -525,7 +525,7 @@ final case class ScalaPbOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = scalapb.options.ScalaPbOptions
+    def companion: scalapb.options.ScalaPbOptions.type = scalapb.options.ScalaPbOptions
     // @@protoc_insertion_point(GeneratedMessage[scalapb.ScalaPbOptions])
 }
 
@@ -912,7 +912,7 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.options.ScalaPbOptions.AuxMessageOptions
+      def companion: scalapb.options.ScalaPbOptions.AuxMessageOptions.type = scalapb.options.ScalaPbOptions.AuxMessageOptions
       // @@protoc_insertion_point(GeneratedMessage[scalapb.ScalaPbOptions.AuxMessageOptions])
   }
   
@@ -1060,7 +1060,7 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.options.ScalaPbOptions.AuxFieldOptions
+      def companion: scalapb.options.ScalaPbOptions.AuxFieldOptions.type = scalapb.options.ScalaPbOptions.AuxFieldOptions
       // @@protoc_insertion_point(GeneratedMessage[scalapb.ScalaPbOptions.AuxFieldOptions])
   }
   
@@ -1208,7 +1208,7 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.options.ScalaPbOptions.AuxEnumOptions
+      def companion: scalapb.options.ScalaPbOptions.AuxEnumOptions.type = scalapb.options.ScalaPbOptions.AuxEnumOptions
       // @@protoc_insertion_point(GeneratedMessage[scalapb.ScalaPbOptions.AuxEnumOptions])
   }
   
@@ -1356,7 +1356,7 @@ object ScalaPbOptions extends scalapb.GeneratedMessageCompanion[scalapb.options.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = scalapb.options.ScalaPbOptions.AuxEnumValueOptions
+      def companion: scalapb.options.ScalaPbOptions.AuxEnumValueOptions.type = scalapb.options.ScalaPbOptions.AuxEnumValueOptions
       // @@protoc_insertion_point(GeneratedMessage[scalapb.ScalaPbOptions.AuxEnumValueOptions])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/any/Any.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/any/Any.scala
@@ -190,7 +190,7 @@ final case class Any(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.any.Any
+    def companion: com.google.protobuf.any.Any.type = com.google.protobuf.any.Any
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Any])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Api.scala
@@ -212,7 +212,7 @@ final case class Api(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Api
+    def companion: com.google.protobuf.api.Api.type = com.google.protobuf.api.Api
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Api])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Method.scala
@@ -194,7 +194,7 @@ final case class Method(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Method
+    def companion: com.google.protobuf.api.Method.type = com.google.protobuf.api.Method
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Method])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Mixin.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/api/Mixin.scala
@@ -164,7 +164,7 @@ final case class Mixin(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.api.Mixin
+    def companion: com.google.protobuf.api.Mixin.type = com.google.protobuf.api.Mixin
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Mixin])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -128,7 +128,7 @@ final case class CodeGeneratorRequest(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.CodeGeneratorRequest
+    def companion: com.google.protobuf.compiler.plugin.CodeGeneratorRequest.type = com.google.protobuf.compiler.plugin.CodeGeneratorRequest
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorRequest])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -100,7 +100,7 @@ final case class CodeGeneratorResponse(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.CodeGeneratorResponse
+    def companion: com.google.protobuf.compiler.plugin.CodeGeneratorResponse.type = com.google.protobuf.compiler.plugin.CodeGeneratorResponse
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorResponse])
 }
 
@@ -352,7 +352,7 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File
+      def companion: com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File.type = com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.CodeGeneratorResponse.File])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/Version.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/compiler/plugin/Version.scala
@@ -101,7 +101,7 @@ final case class Version(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.compiler.plugin.Version
+    def companion: com.google.protobuf.compiler.plugin.Version.type = com.google.protobuf.compiler.plugin.Version
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.compiler.Version])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -210,7 +210,7 @@ final case class DescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.DescriptorProto
+    def companion: com.google.protobuf.descriptor.DescriptorProto.type = com.google.protobuf.descriptor.DescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto])
 }
 
@@ -434,7 +434,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.DescriptorProto.ExtensionRange
+      def companion: com.google.protobuf.descriptor.DescriptorProto.ExtensionRange.type = com.google.protobuf.descriptor.DescriptorProto.ExtensionRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto.ExtensionRange])
   }
   
@@ -602,7 +602,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.DescriptorProto.ReservedRange
+      def companion: com.google.protobuf.descriptor.DescriptorProto.ReservedRange.type = com.google.protobuf.descriptor.DescriptorProto.ReservedRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DescriptorProto.ReservedRange])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -129,7 +129,7 @@ final case class EnumDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumDescriptorProto
+    def companion: com.google.protobuf.descriptor.EnumDescriptorProto.type = com.google.protobuf.descriptor.EnumDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumDescriptorProto])
 }
 
@@ -298,7 +298,7 @@ object EnumDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange
+      def companion: com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange.type = com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumDescriptorProto.EnumReservedRange])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumOptions.scala
@@ -96,7 +96,7 @@ final case class EnumOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumOptions
+    def companion: com.google.protobuf.descriptor.EnumOptions.type = com.google.protobuf.descriptor.EnumOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -85,7 +85,7 @@ final case class EnumValueDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumValueDescriptorProto
+    def companion: com.google.protobuf.descriptor.EnumValueDescriptorProto.type = com.google.protobuf.descriptor.EnumValueDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValueDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -79,7 +79,7 @@ final case class EnumValueOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.EnumValueOptions
+    def companion: com.google.protobuf.descriptor.EnumValueOptions.type = com.google.protobuf.descriptor.EnumValueOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValueOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
@@ -60,7 +60,7 @@ final case class ExtensionRangeOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ExtensionRangeOptions
+    def companion: com.google.protobuf.descriptor.ExtensionRangeOptions.type = com.google.protobuf.descriptor.ExtensionRangeOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ExtensionRangeOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -246,7 +246,7 @@ final case class FieldDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FieldDescriptorProto
+    def companion: com.google.protobuf.descriptor.FieldDescriptorProto.type = com.google.protobuf.descriptor.FieldDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FieldOptions.scala
@@ -203,7 +203,7 @@ final case class FieldOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FieldOptions
+    def companion: com.google.protobuf.descriptor.FieldOptions.type = com.google.protobuf.descriptor.FieldOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -251,7 +251,7 @@ final case class FileDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileDescriptorProto
+    def companion: com.google.protobuf.descriptor.FileDescriptorProto.type = com.google.protobuf.descriptor.FileDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -60,7 +60,7 @@ final case class FileDescriptorSet(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileDescriptorSet
+    def companion: com.google.protobuf.descriptor.FileDescriptorSet.type = com.google.protobuf.descriptor.FileDescriptorSet
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileDescriptorSet])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/FileOptions.scala
@@ -418,7 +418,7 @@ final case class FileOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.FileOptions
+    def companion: com.google.protobuf.descriptor.FileOptions.type = com.google.protobuf.descriptor.FileOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FileOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -65,7 +65,7 @@ final case class GeneratedCodeInfo(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.GeneratedCodeInfo
+    def companion: com.google.protobuf.descriptor.GeneratedCodeInfo.type = com.google.protobuf.descriptor.GeneratedCodeInfo
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.GeneratedCodeInfo])
 }
 
@@ -240,7 +240,7 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation
+      def companion: com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation.type = com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.GeneratedCodeInfo.Annotation])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MessageOptions.scala
@@ -166,7 +166,7 @@ final case class MessageOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MessageOptions
+    def companion: com.google.protobuf.descriptor.MessageOptions.type = com.google.protobuf.descriptor.MessageOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MessageOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -135,7 +135,7 @@ final case class MethodDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MethodDescriptorProto
+    def companion: com.google.protobuf.descriptor.MethodDescriptorProto.type = com.google.protobuf.descriptor.MethodDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MethodDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/MethodOptions.scala
@@ -93,7 +93,7 @@ final case class MethodOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.MethodOptions
+    def companion: com.google.protobuf.descriptor.MethodOptions.type = com.google.protobuf.descriptor.MethodOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.MethodOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -71,7 +71,7 @@ final case class OneofDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.OneofDescriptorProto
+    def companion: com.google.protobuf.descriptor.OneofDescriptorProto.type = com.google.protobuf.descriptor.OneofDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.OneofDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/OneofOptions.scala
@@ -60,7 +60,7 @@ final case class OneofOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.OneofOptions
+    def companion: com.google.protobuf.descriptor.OneofOptions.type = com.google.protobuf.descriptor.OneofOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.OneofOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -89,7 +89,7 @@ final case class ServiceDescriptorProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ServiceDescriptorProto
+    def companion: com.google.protobuf.descriptor.ServiceDescriptorProto.type = com.google.protobuf.descriptor.ServiceDescriptorProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ServiceDescriptorProto])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -79,7 +79,7 @@ final case class ServiceOptions(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.ServiceOptions
+    def companion: com.google.protobuf.descriptor.ServiceOptions.type = com.google.protobuf.descriptor.ServiceOptions
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ServiceOptions])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -105,7 +105,7 @@ final case class SourceCodeInfo(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.SourceCodeInfo
+    def companion: com.google.protobuf.descriptor.SourceCodeInfo.type = com.google.protobuf.descriptor.SourceCodeInfo
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceCodeInfo])
 }
 
@@ -372,7 +372,7 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.SourceCodeInfo.Location
+      def companion: com.google.protobuf.descriptor.SourceCodeInfo.Location.type = com.google.protobuf.descriptor.SourceCodeInfo.Location
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceCodeInfo.Location])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -152,7 +152,7 @@ final case class UninterpretedOption(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.descriptor.UninterpretedOption
+    def companion: com.google.protobuf.descriptor.UninterpretedOption.type = com.google.protobuf.descriptor.UninterpretedOption
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UninterpretedOption])
 }
 
@@ -329,7 +329,7 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.descriptor.UninterpretedOption.NamePart
+      def companion: com.google.protobuf.descriptor.UninterpretedOption.NamePart.type = com.google.protobuf.descriptor.UninterpretedOption.NamePart
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UninterpretedOption.NamePart])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/duration/Duration.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/duration/Duration.scala
@@ -150,7 +150,7 @@ final case class Duration(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.duration.Duration
+    def companion: com.google.protobuf.duration.Duration.type = com.google.protobuf.duration.Duration
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Duration])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/empty/Empty.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/empty/Empty.scala
@@ -42,7 +42,7 @@ final case class Empty(
     def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = throw new MatchError(__fieldNumber)
     def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = throw new MatchError(__field)
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.empty.Empty
+    def companion: com.google.protobuf.empty.Empty.type = com.google.protobuf.empty.Empty
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Empty])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/field_mask/FieldMask.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/field_mask/FieldMask.scala
@@ -258,7 +258,7 @@ final case class FieldMask(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.field_mask.FieldMask
+    def companion: com.google.protobuf.field_mask.FieldMask.type = com.google.protobuf.field_mask.FieldMask
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FieldMask])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/source_context/SourceContext.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/source_context/SourceContext.scala
@@ -66,7 +66,7 @@ final case class SourceContext(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.source_context.SourceContext
+    def companion: com.google.protobuf.source_context.SourceContext.type = com.google.protobuf.source_context.SourceContext
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.SourceContext])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/ListValue.scala
@@ -64,7 +64,7 @@ final case class ListValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.ListValue
+    def companion: com.google.protobuf.struct.ListValue.type = com.google.protobuf.struct.ListValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.ListValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/Struct.scala
@@ -69,7 +69,7 @@ final case class Struct(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.Struct
+    def companion: com.google.protobuf.struct.Struct.type = com.google.protobuf.struct.Struct
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Struct])
 }
 
@@ -203,7 +203,7 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
         }
       }
       def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-      def companion = com.google.protobuf.struct.Struct.FieldsEntry
+      def companion: com.google.protobuf.struct.Struct.FieldsEntry.type = com.google.protobuf.struct.Struct.FieldsEntry
       // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Struct.FieldsEntry])
   }
   

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/struct/Value.scala
@@ -125,7 +125,7 @@ final case class Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.struct.Value
+    def companion: com.google.protobuf.struct.Value.type = com.google.protobuf.struct.Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Value])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/timestamp/Timestamp.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/timestamp/Timestamp.scala
@@ -172,7 +172,7 @@ final case class Timestamp(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.timestamp.Timestamp
+    def companion: com.google.protobuf.timestamp.Timestamp.type = com.google.protobuf.timestamp.Timestamp
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Timestamp])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Enum.scala
@@ -143,7 +143,7 @@ final case class Enum(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Enum
+    def companion: com.google.protobuf.`type`.Enum.type = com.google.protobuf.`type`.Enum
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Enum])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/EnumValue.scala
@@ -106,7 +106,7 @@ final case class EnumValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.EnumValue
+    def companion: com.google.protobuf.`type`.EnumValue.type = com.google.protobuf.`type`.EnumValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.EnumValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Field.scala
@@ -262,7 +262,7 @@ final case class Field(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Field
+    def companion: com.google.protobuf.`type`.Field.type = com.google.protobuf.`type`.Field
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Field])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/OptionProto.scala
@@ -89,7 +89,7 @@ final case class OptionProto(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.OptionProto
+    def companion: com.google.protobuf.`type`.OptionProto.type = com.google.protobuf.`type`.OptionProto
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Option])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/type/Type.scala
@@ -160,7 +160,7 @@ final case class Type(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.`type`.Type
+    def companion: com.google.protobuf.`type`.Type.type = com.google.protobuf.`type`.Type
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Type])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/BoolValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/BoolValue.scala
@@ -66,7 +66,7 @@ final case class BoolValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.BoolValue
+    def companion: com.google.protobuf.wrappers.BoolValue.type = com.google.protobuf.wrappers.BoolValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.BoolValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/BytesValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/BytesValue.scala
@@ -66,7 +66,7 @@ final case class BytesValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.BytesValue
+    def companion: com.google.protobuf.wrappers.BytesValue.type = com.google.protobuf.wrappers.BytesValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.BytesValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/DoubleValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/DoubleValue.scala
@@ -66,7 +66,7 @@ final case class DoubleValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.DoubleValue
+    def companion: com.google.protobuf.wrappers.DoubleValue.type = com.google.protobuf.wrappers.DoubleValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.DoubleValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/FloatValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/FloatValue.scala
@@ -66,7 +66,7 @@ final case class FloatValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.FloatValue
+    def companion: com.google.protobuf.wrappers.FloatValue.type = com.google.protobuf.wrappers.FloatValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.FloatValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/Int32Value.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/Int32Value.scala
@@ -66,7 +66,7 @@ final case class Int32Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.Int32Value
+    def companion: com.google.protobuf.wrappers.Int32Value.type = com.google.protobuf.wrappers.Int32Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Int32Value])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/Int64Value.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/Int64Value.scala
@@ -66,7 +66,7 @@ final case class Int64Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.Int64Value
+    def companion: com.google.protobuf.wrappers.Int64Value.type = com.google.protobuf.wrappers.Int64Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.Int64Value])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/StringValue.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/StringValue.scala
@@ -66,7 +66,7 @@ final case class StringValue(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.StringValue
+    def companion: com.google.protobuf.wrappers.StringValue.type = com.google.protobuf.wrappers.StringValue
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.StringValue])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/UInt32Value.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/UInt32Value.scala
@@ -66,7 +66,7 @@ final case class UInt32Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.UInt32Value
+    def companion: com.google.protobuf.wrappers.UInt32Value.type = com.google.protobuf.wrappers.UInt32Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UInt32Value])
 }
 

--- a/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/UInt64Value.scala
+++ b/scalapb-runtime/src/main/scalajvm/com/google/protobuf/wrappers/UInt64Value.scala
@@ -66,7 +66,7 @@ final case class UInt64Value(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
-    def companion = com.google.protobuf.wrappers.UInt64Value
+    def companion: com.google.protobuf.wrappers.UInt64Value.type = com.google.protobuf.wrappers.UInt64Value
     // @@protoc_insertion_point(GeneratedMessage[google.protobuf.UInt64Value])
 }
 


### PR DESCRIPTION
Towards https://github.com/scalapb/ScalaPB/issues/1174, to support https://github.com/scalapb/scalapb-json4s/blob/8aab692afe26db25398ed1333eaf702a331e6bab/src/main/scala/scalapb/json4s/JsonFormat.scala#L46-L68

Interestingly, the return type of the `companion` method on enums is explicitly set to the super type instead of the concrete one like this PR is doing on messages:
https://github.com/scalapb/ScalaPB/blob/c47f8a3a2eab6fb819414ec314b16b779f2d53bd/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala#L26-L41

It's not a problem for scalapb-json4s as the companion type is captured as an implicit https://github.com/scalapb/scalapb-json4s/blob/8aab692afe26db25398ed1333eaf702a331e6bab/src/main/scala/scalapb/json4s/JsonFormat.scala#L70-L80, so we don't rely on the returned type looked up via reflection.

Coming back to messages: maybe `registerMessageFormatter` as-is should be deprecated and an overload with a companion type rather than a `ClassTag` should be favored?