### PR TITLE
Drop `.for3Use2_13` cross option for scala-collection-compat

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -61,7 +61,6 @@ object BuildHelper {
                                               else scalac2Options),
     libraryDependencies ++= (if (!isScala3.value) Dependencies.silencer else Nil),
     libraryDependencies += Dependencies.scalaCollectionCompat.value
-      .cross(CrossVersion.for3Use2_13),
     Compile / unmanagedSourceDirectories += (Compile / scalaSource).value.getParentFile / (if (
                                                                                              isScala3.value
                                                                                            )

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -60,7 +60,7 @@ object BuildHelper {
     scalacOptions ++= commonScalacOptions ++ (if (isScala3.value) scalac3Options
                                               else scalac2Options),
     libraryDependencies ++= (if (!isScala3.value) Dependencies.silencer else Nil),
-    libraryDependencies += Dependencies.scalaCollectionCompat.value
+    libraryDependencies += Dependencies.scalaCollectionCompat.value,
     Compile / unmanagedSourceDirectories += (Compile / scalaSource).value.getParentFile / (if (
                                                                                              isScala3.value
                                                                                            )


### PR DESCRIPTION
This option is dangerous for using in libs, outdated since scala-collection-compat is published under Scala 3, and causes conflicts in Scala 3 projects.

We need a new release, please.