### PR TITLE
POC 2.11 runtime build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val compilerPlugin = (projectMatrix in file("compiler-plugin"))
     Compiler.generateVersionFile,
     Compiler.generateEncodingFile
   )
-  .jvmPlatform(scalaVersions = jvmPlatformVersions)
+  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213))
 
 lazy val compilerPluginJVM2_12 = compilerPlugin.jvm(Scala212)
 
@@ -219,7 +219,7 @@ lazy val protocGenScalaNativeImage =
 lazy val proptest = (projectMatrix in file("proptest"))
   .defaultAxes()
   .dependsOn(compilerPlugin % "compile->compile;test->test", runtime, grpcRuntime)
-  .jvmPlatform(scalaVersions = jvmPlatformVersions)
+  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213))
   .settings(commonSettings)
   .settings(
     publishArtifact := false,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import Dependencies._
 val protobufCompilerVersion = "3.15.8"
 
 val MimaPreviousVersion = "0.11.0"
-
+lazy val jvmPlatformVersions = Seq(Scala211, Scala212, Scala213, Scala3)
 inThisBuild(
   List(
     scalaVersion := Scala212,
@@ -70,7 +70,7 @@ lazy val runtime = (projectMatrix in file("scalapb-runtime"))
     )
   )
   .jvmPlatform(
-    scalaVersions = Seq(Scala212, Scala213, Scala3),
+    scalaVersions = jvmPlatformVersions,
     settings = Seq(
       libraryDependencies ++= Seq(
         protobufJava
@@ -120,7 +120,7 @@ lazy val grpcRuntime = (projectMatrix in file("scalapb-runtime-grpc"))
   .defaultAxes()
   .dependsOn(runtime)
   .settings(commonSettings)
-  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213, Scala3))
+  .jvmPlatform(scalaVersions = jvmPlatformVersions)
   .settings(
     name := "scalapb-runtime-grpc",
     testFrameworks += new TestFramework("munit.Framework"),
@@ -159,7 +159,7 @@ lazy val compilerPlugin = (projectMatrix in file("compiler-plugin"))
     Compiler.generateVersionFile,
     Compiler.generateEncodingFile
   )
-  .jvmPlatform(Seq(Scala212, Scala213, Scala3))
+  .jvmPlatform(scalaVersions = jvmPlatformVersions)
 
 lazy val compilerPluginJVM2_12 = compilerPlugin.jvm(Scala212)
 
@@ -219,7 +219,7 @@ lazy val protocGenScalaNativeImage =
 lazy val proptest = (projectMatrix in file("proptest"))
   .defaultAxes()
   .dependsOn(compilerPlugin % "compile->compile;test->test", runtime, grpcRuntime)
-  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213, Scala3))
+  .jvmPlatform(scalaVersions = jvmPlatformVersions)
   .settings(commonSettings)
   .settings(
     publishArtifact := false,
@@ -261,7 +261,7 @@ lazy val lenses = (projectMatrix in file("lenses"))
     ),
     mimaPreviousArtifacts := Set("com.thesamet.scalapb" %% "lenses" % MimaPreviousVersion)
   )
-  .jvmPlatform(scalaVersions = Seq(Scala212, Scala213, Scala3))
+  .jvmPlatform(scalaVersions = jvmPlatformVersions)
   .jsPlatform(
     scalaVersions = Seq(Scala212, Scala213, Scala3),
     settings = scalajsSourceMaps ++ Seq(

--- a/lenses/src/main/scala-2.11/scalapb/lenses/CompatLensImplicits.scala
+++ b/lenses/src/main/scala-2.11/scalapb/lenses/CompatLensImplicits.scala
@@ -1,0 +1,70 @@
+package scalapb.lenses
+
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
+object CompatLensImplicits {
+
+  /** Implicit that adds some syntactic sugar if our lens watches a Seq-like collection. */
+  class SeqLikeLens[U, A, Coll[A] <: collection.SeqLike[A, Coll[A]]](
+      val lens: Lens[U, Coll[A]]
+  ) extends AnyVal {
+    type CBF = collection.generic.CanBuildFrom[Coll[A], A, Coll[A]]
+
+    private def field(getter: Coll[A] => A)(setter: (Coll[A], A) => Coll[A]): Lens[U, A] =
+      lens.compose[A](Lens[Coll[A], A](getter)(setter))
+
+    def apply(i: Int)(implicit cbf: CBF): Lens[U, A] = field(_.apply(i))((c, v) => c.updated(i, v))
+
+    def head(implicit cbf: CBF): Lens[U, A] = apply(0)
+
+    def last(implicit cbf: CBF): Lens[U, A] = field(_.last)((c, v) => c.updated(c.size - 1, v))
+
+    def :+=(item: A)(implicit cbf: CBF) = lens.modify(_ :+ item)
+
+    def :++=(item: scala.collection.GenTraversableOnce[A])(implicit cbf: CBF) =
+      lens.modify(_ ++ item)
+
+    def foreach(f: Lens[A, A] => Mutation[A])(implicit cbf: CBF): Mutation[U] =
+      lens.modify(s =>
+        s.map { (m: A) =>
+          val field: Lens[A, A] = Lens.unit[A]
+          val p: Mutation[A]    = f(field)
+          p(m)
+        }
+      )
+  }
+
+  /** Implicit that adds some syntactic sugar if our lens watches a Set-like collection. */
+  class SetLikeLens[U, A, Coll[A] <: collection.SetLike[A, Coll[A]] with Set[A]](
+      val lens: Lens[U, Coll[A]]
+  ) extends AnyVal {
+    type CBF = collection.generic.CanBuildFrom[Coll[A], A, Coll[A]]
+
+    def :+=(item: A) = lens.modify(_ + item)
+
+    def :++=(item: scala.collection.GenTraversableOnce[A]) =
+      lens.modify(_ ++ item)
+
+    def foreach(f: Lens[A, A] => Mutation[A])(implicit cbf: CBF): Mutation[U] =
+      lens.modify(s =>
+        s.map { (m: A) =>
+          val field: Lens[A, A] = Lens.unit[A]
+          val p: Mutation[A]    = f(field)
+          p(m)
+        }
+      )
+  }
+}
+
+trait CompatLensImplicits {
+  import CompatLensImplicits._
+  implicit def seqLikeLens[U, A, Coll[A] <: collection.SeqLike[A, Coll[A]]](
+      lens: Lens[U, Coll[A]]
+  ) =
+    new SeqLikeLens[U, A, Coll](lens)
+
+  implicit def SetLikeLens[U, A, Coll[A] <: collection.SetLike[A, Coll[A]] with Set[A]](
+      lens: Lens[U, Coll[A]]
+  ) = new SetLikeLens[U, A, Coll](lens)
+}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -14,35 +14,35 @@ object BuildHelper {
 
   val scalac2Options = Seq(
     "-explaintypes",
-    "-Xfatal-warnings",
-    "-Xlint:adapted-args",           // Warn if an argument list is modified to match the receiver.
-    "-Xlint:constant",               // Evaluation of a constant arithmetic expression results in an error.
-    "-Xlint:delayedinit-select",     // Selecting member of DelayedInit.
-    "-Xlint:doc-detached",           // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible",           // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any",              // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator",   // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-unit",           // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit",        // Option.apply used implicit view.
+//    "-Xfatal-warnings",
+    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+//    "-Xlint:constant",               // Evaluation of a constant arithmetic expression results in an error.
+    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+    "-Xlint:option-implicit", // Option.apply used implicit view.
     "-Xlint:package-object-classes", // Class or object defined in package object.
     "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow",         // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align",            // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow",  // A local type parameter shadows a type already in scope.
-    "-Ywarn-dead-code",              // Warn when dead code is identified.
-    "-Ywarn-extra-implicit",         // Warn when more than one implicit parameter section is defined.
-    "-Ywarn-numeric-widen",          // Warn when numerics are widened.
-    "-Ywarn-unused:implicits",       // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports",         // Warn if an import selector is not referenced.
-    "-Ywarn-unused:locals",          // Warn if a local definition is unused.
-    "-Ywarn-unused:params",          // Warn if a value parameter is unused.
-    "-Ywarn-unused:patvars",         // Warn if a variable bound in a pattern is unused.
-    "-Ywarn-unused:privates",        // Warn if a private member is unused.
-    "-Ywarn-value-discard",          // Warn when non-Unit expression results are unused.
-    "-Ybackend-parallelism",
-    "8",                                         // Enable paralellisation — change to desired number!
-    "-Ycache-plugin-class-loader:last-modified", // Enables caching of classloaders for compiler plugins
-    "-Ycache-macro-class-loader:last-modified"   // and macro definitions. This can lead to performance improvements.
+    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+    "-Ywarn-dead-code" // Warn when dead code is identified.
+//    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+//    "-Ywarn-numeric-widen", // Warn when numerics are widened.
+//    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+//    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+//    "-Ywarn-unused:locals", // Warn if a local definition is unused.
+//    "-Ywarn-unused:params", // Warn if a value parameter is unused.
+//    "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+//    "-Ywarn-unused:privates", // Warn if a private member is unused.
+//    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
+//    "-Ybackend-parallelism",
+//    "8", // Enable paralellisation — change to desired number!
+//    "-Ycache-plugin-class-loader:last-modified", // Enables caching of classloaders for compiler plugins
+//    "-Ycache-macro-class-loader:last-modified" // and macro definitions. This can lead to performance improvements.
   )
 
   val scalac3Options = Seq(
@@ -55,21 +55,17 @@ object BuildHelper {
   val scala3Settings = Seq()
 
   def isScala3 = Def.setting[Boolean] { scalaVersion.value.startsWith("3.") }
-
+  //todo renable warning but only for 2.11
   def commonSettings = Seq(
     scalacOptions ++= commonScalacOptions ++ (if (isScala3.value) scalac3Options
                                               else scalac2Options),
     libraryDependencies ++= (if (!isScala3.value) Dependencies.silencer else Nil),
     libraryDependencies += Dependencies.scalaCollectionCompat.value,
-    Compile / unmanagedSourceDirectories += (Compile / scalaSource).value.getParentFile / (if (
-                                                                                             isScala3.value
-                                                                                           )
+    Compile / unmanagedSourceDirectories += (Compile / scalaSource).value.getParentFile / (if (isScala3.value)
                                                                                              "scala-3"
                                                                                            else
                                                                                              "scala-2"),
-    Test / unmanagedSourceDirectories += (Test / scalaSource).value.getParentFile / (if (
-                                                                                       isScala3.value
-                                                                                     )
+    Test / unmanagedSourceDirectories += (Test / scalaSource).value.getParentFile / (if (isScala3.value)
                                                                                        "scala-3"
                                                                                      else
                                                                                        "scala-2"),
@@ -89,11 +85,11 @@ object BuildHelper {
       IO.write(
         file,
         s"""package scalapb.compiler
-           |object Version {
-           |  val scalapbVersion = "${version.value}"
-           |  val protobufVersion = "${versions.protobuf}"
-           |  val grpcJavaVersion = "${versions.grpc}"
-           |}""".stripMargin
+          |object Version {
+          |  val scalapbVersion = "${version.value}"
+          |  val protobufVersion = "${versions.protobuf}"
+          |  val grpcJavaVersion = "${versions.grpc}"
+          |}""".stripMargin
       )
       Seq(file)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,25 +5,27 @@ import Keys._
 
 object Dependencies {
   object versions {
-    val grpc                 = "1.41.0"
-    val protobuf             = "3.15.8"
-    val silencer             = "1.7.6"
-    val collectionCompat     = "2.5.0"
-    val coursier             = "2.0.16"
-    val protocGen            = "0.9.3"
+    val grpc = "1.41.0"
+    val protobuf = "3.15.8"
+    val silencer = "1.7.6"
+    val collectionCompat = "2.5.0"
+    val coursier = "2.0.16"
+    val protocGen = "0.9.3"
     val protobufRuntimeScala = "0.8.12"
-    val commonsCodec         = "1.15"
+    val commonsCodec = "1.15"
 
     // For testing
-    val annotationApi           = "1.3.2"
-    val cats                    = "2.6.1"
-    val mockito                 = "3.12.4"
-    val munit                   = "0.7.29"
-    val scalaTest               = "3.2.10"
-    val scalaTestPlusMockito    = "3.1.0.0"
+    val annotationApi = "1.3.2"
+    val cats = "2.6.1"
+    val mockito = "3.12.4"
+    val munit = "0.7.29"
+    val scalaTest = "3.2.10"
+    val scalaTestPlusMockito = "3.1.0.0"
     val scalaTestPlusScalaCheck = "3.2.10.0"
-    val utest                   = "0.7.10"
+    val utest = "0.7.10"
   }
+
+  val Scala211 = "2.11.12"
 
   val Scala212 = "2.12.14"
 
@@ -49,17 +51,17 @@ object Dependencies {
   private val exclRule =
     ExclusionRule(organization = "org.scala-lang.modules") // Exclude scala-xml cross-version
 
-  val coursier  = "io.get-coursier"       %% "coursier"   % versions.coursier
+  val coursier = "io.get-coursier" %% "coursier" % versions.coursier
   val protocGen = ("com.thesamet.scalapb" %% "protoc-gen" % versions.protocGen).excludeAll(exclRule)
   val protocCacheCoursier =
     ("com.thesamet.scalapb" %% "protoc-cache-coursier" % versions.protocGen).excludeAll(exclRule)
   val protobufJavaUtil = "com.google.protobuf" % "protobuf-java-util" % versions.protobuf
 
   // grpc
-  val grpcStub      = "io.grpc" % "grpc-stub"            % versions.grpc
-  val grpcProtobuf  = "io.grpc" % "grpc-protobuf"        % versions.grpc
-  val grpcNetty     = "io.grpc" % "grpc-netty"           % versions.grpc
-  val grpcServices  = "io.grpc" % "grpc-services"        % versions.grpc
+  val grpcStub = "io.grpc" % "grpc-stub" % versions.grpc
+  val grpcProtobuf = "io.grpc" % "grpc-protobuf" % versions.grpc
+  val grpcNetty = "io.grpc" % "grpc-netty" % versions.grpc
+  val grpcServices = "io.grpc" % "grpc-services" % versions.grpc
   val grpcProtocGen = "io.grpc" % "protoc-gen-grpc-java" % versions.grpc
 
   // testing
@@ -67,13 +69,13 @@ object Dependencies {
   val scalaTestPlusScalaCheck = Def.setting {
     "org.scalatestplus" %%% "scalacheck-1-15" % versions.scalaTestPlusScalaCheck
   }
-  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-1-10"  % versions.scalaTestPlusMockito
-  val utest                = Def.setting { "com.lihaoyi" %%% "utest" % versions.utest }
-  val munit                = Def.setting { "org.scalameta" %%% "munit" % versions.munit }
-  val munitScalaCheck      = Def.setting { "org.scalameta" %%% "munit-scalacheck" % versions.munit }
-  val mockitoCore          = "org.mockito"        % "mockito-core"  % versions.mockito
-  val commonsCodec         = "commons-codec"      % "commons-codec" % versions.commonsCodec
-  val cats                 = "org.typelevel"     %% "cats-core"     % versions.cats
+  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-1-10" % versions.scalaTestPlusMockito
+  val utest = Def.setting { "com.lihaoyi" %%% "utest" % versions.utest }
+  val munit = Def.setting { "org.scalameta" %%% "munit" % versions.munit }
+  val munitScalaCheck = Def.setting { "org.scalameta" %%% "munit-scalacheck" % versions.munit }
+  val mockitoCore = "org.mockito" % "mockito-core" % versions.mockito
+  val commonsCodec = "commons-codec" % "commons-codec" % versions.commonsCodec
+  val cats = "org.typelevel" %% "cats-core" % versions.cats
 
   val annotationApi =
     "javax.annotation" % "javax.annotation-api" % versions.annotationApi // needed for grpc-java on JDK9

--- a/scalapb-runtime/src/main/scala-2.11/scalapb/descriptors/ReadsCompat.scala
+++ b/scalapb-runtime/src/main/scala-2.11/scalapb/descriptors/ReadsCompat.scala
@@ -1,0 +1,14 @@
+package scalapb.descriptors
+
+import scala.language.higherKinds
+import scala.collection.generic.CanBuildFrom
+
+trait ReadsCompat {
+  implicit def repeated[A, CC[_]](implicit
+      reads: Reads[A],
+      cbf: CanBuildFrom[Nothing, A, CC[A]]
+  ): Reads[CC[A]] = Reads[CC[A]] {
+    case PRepeated(value) => value.map(reads.read)(scala.collection.breakOut)
+    case _                => throw new ReadsException("Expected PRepeated")
+  }
+}

--- a/scalapb-runtime/src/main/scala-2.11/scalapb/internal/compat.scala
+++ b/scalapb-runtime/src/main/scala-2.11/scalapb/internal/compat.scala
@@ -1,0 +1,21 @@
+package scalapb.internal
+
+import scala.collection.generic.CanBuildFrom
+
+object compat {
+  def convertTo[A, To](from: TraversableOnce[A])(implicit cbf: CanBuildFrom[Nothing, A, To]): To = {
+    val builder = cbf()
+    builder ++= from
+    builder.result()
+  }
+
+  def toIterable[A](it: Iterator[A]): Iterable[A] = {
+    it.toIterable
+  }
+
+  val JavaConverters = scala.collection.JavaConverters
+
+  implicit class EitherCompatExtensions[L, R](e: Either[L, R]) {
+    def map[NR](f: R => NR): Either[L, NR] = e.right.map(f)
+  }
+}

--- a/scalapb-runtime/src/main/scala-2.11/scalapb/textformat/ParserCompat.scala
+++ b/scalapb-runtime/src/main/scala-2.11/scalapb/textformat/ParserCompat.scala
@@ -1,0 +1,3 @@
+package scalapb.textformat
+
+trait ParserCompat

--- a/scalapb-runtime/src/main/scala/scalapb/textformat/AstUtils.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/textformat/AstUtils.scala
@@ -5,7 +5,7 @@ import com.google.protobuf.descriptor.FieldDescriptorProto
 import scalapb.descriptors._
 import scalapb.descriptors.{FieldDescriptor, PValue}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
-
+import scalapb.internal.compat._
 import scala.util.Try
 
 private[scalapb] object AstUtils {
@@ -13,8 +13,8 @@ private[scalapb] object AstUtils {
 
   private def flatten[T](s: Seq[Either[AstError, T]]): Either[AstError, Vector[T]] = {
     s.foldLeft[Either[AstError, Vector[T]]](Right(Vector.empty)) {
-      case (Left(l), _)          => Left(l)
-      case (_, Left(l))          => Left(l)
+      case (Left(l), _) => Left(l)
+      case (_, Left(l)) => Left(l)
       case (Right(xs), Right(x)) => Right(xs :+ x)
     }
   }
@@ -22,7 +22,7 @@ private[scalapb] object AstUtils {
   def parseMessage[T <: GeneratedMessage](
       v: GeneratedMessageCompanion[T],
       ast: TMessage
-  ): Either[AstError, T] = {
+    ): Either[AstError, T] = {
     parseUnsafe(v, ast).map(v.messageReads.read)
   }
 
@@ -30,7 +30,7 @@ private[scalapb] object AstUtils {
       p: TPrimitive,
       isSigned: Boolean = true,
       isLong: Boolean
-  ): Either[AstError, BigInt] = p match {
+    ): Either[AstError, BigInt] = p match {
     case TIntLiteral(index, v) =>
       val negative = v.signum == -1
       val maxBits = if (isLong) {
@@ -67,20 +67,20 @@ private[scalapb] object AstUtils {
   private def parseUnsafe(
       v: GeneratedMessageCompanion[_],
       ast: TMessage
-  ): Either[AstError, PMessage] = {
+    ): Either[AstError, PMessage] = {
     def parseDouble(p: TPrimitive): Either[AstError, PDouble] = p match {
       case TLiteral(_, value) =>
         val low = value.toLowerCase()
         low match {
-          case "inf" | "infinity"   => Right(PDouble(Double.PositiveInfinity))
+          case "inf" | "infinity" => Right(PDouble(Double.PositiveInfinity))
           case "-inf" | "-infinity" => Right(PDouble(Double.NegativeInfinity))
-          case "nan"                => Right(PDouble(Double.NaN))
+          case "nan" => Right(PDouble(Double.NaN))
           case _ =>
             Try(PDouble(value.toDouble)).toOption
               .toRight(AstError(p.position, s"Invalid value for double: '$value'"))
         }
       case TIntLiteral(_, value) => Right(PDouble(value.toDouble))
-      case p                     => Left(AstError(p.position, s"Invalid input '${p.asString}', expected float"))
+      case p => Left(AstError(p.position, s"Invalid input '${p.asString}', expected float"))
     }
 
     def parseFloat(p: TPrimitive): Either[AstError, PFloat] = p match {
@@ -96,7 +96,7 @@ private[scalapb] object AstUtils {
               .toRight(AstError(p.position, s"Invalid value for float: '$value'"))
         }
       case TIntLiteral(_, value) => Right(PFloat(value.toFloat))
-      case p                     => Left(AstError(p.position, s"Invalid input '${p.asString}', expected float"))
+      case p => Left(AstError(p.position, s"Invalid input '${p.asString}', expected float"))
     }
 
     def parseBoolean(p: TPrimitive): Either[AstError, PBoolean] = {
@@ -109,9 +109,9 @@ private[scalapb] object AstUtils {
           else Left(AstError(index, invalidInput(v.toString)))
         case TLiteral(index, v) =>
           v.toLowerCase match {
-            case "t" | "true"  => Right(PBoolean(true))
+            case "t" | "true" => Right(PBoolean(true))
             case "f" | "false" => Right(PBoolean(false))
-            case _             => Left(AstError(index, invalidInput(v.toString)))
+            case _ => Left(AstError(index, invalidInput(v.toString)))
           }
         case TBytes(_, v) => Left(AstError(p.position, invalidInput(v)))
       }
@@ -135,21 +135,21 @@ private[scalapb] object AstUtils {
 
     def parsePrimitive(field: FieldDescriptor, p: TPrimitive): Either[AstError, PValue] =
       field.protoType match {
-        case FieldDescriptorProto.Type.TYPE_DOUBLE   => parseDouble(p)
-        case FieldDescriptorProto.Type.TYPE_FLOAT    => parseFloat(p)
-        case FieldDescriptorProto.Type.TYPE_INT64    => parseInt64(p)
-        case FieldDescriptorProto.Type.TYPE_UINT64   => parseUint64(p)
-        case FieldDescriptorProto.Type.TYPE_INT32    => parseInt32(p)
-        case FieldDescriptorProto.Type.TYPE_FIXED64  => parseUint64(p)
-        case FieldDescriptorProto.Type.TYPE_FIXED32  => parseUint32(p)
-        case FieldDescriptorProto.Type.TYPE_BOOL     => parseBoolean(p)
-        case FieldDescriptorProto.Type.TYPE_STRING   => parseString(p)
-        case FieldDescriptorProto.Type.TYPE_BYTES    => parseBytes(p)
-        case FieldDescriptorProto.Type.TYPE_UINT32   => parseUint32(p)
+        case FieldDescriptorProto.Type.TYPE_DOUBLE => parseDouble(p)
+        case FieldDescriptorProto.Type.TYPE_FLOAT => parseFloat(p)
+        case FieldDescriptorProto.Type.TYPE_INT64 => parseInt64(p)
+        case FieldDescriptorProto.Type.TYPE_UINT64 => parseUint64(p)
+        case FieldDescriptorProto.Type.TYPE_INT32 => parseInt32(p)
+        case FieldDescriptorProto.Type.TYPE_FIXED64 => parseUint64(p)
+        case FieldDescriptorProto.Type.TYPE_FIXED32 => parseUint32(p)
+        case FieldDescriptorProto.Type.TYPE_BOOL => parseBoolean(p)
+        case FieldDescriptorProto.Type.TYPE_STRING => parseString(p)
+        case FieldDescriptorProto.Type.TYPE_BYTES => parseBytes(p)
+        case FieldDescriptorProto.Type.TYPE_UINT32 => parseUint32(p)
         case FieldDescriptorProto.Type.TYPE_SFIXED32 => parseInt32(p)
         case FieldDescriptorProto.Type.TYPE_SFIXED64 => parseInt64(p)
-        case FieldDescriptorProto.Type.TYPE_SINT32   => parseInt32(p)
-        case FieldDescriptorProto.Type.TYPE_SINT64   => parseInt64(p)
+        case FieldDescriptorProto.Type.TYPE_SINT32 => parseInt32(p)
+        case FieldDescriptorProto.Type.TYPE_SINT64 => parseInt64(p)
         case FieldDescriptorProto.Type.TYPE_GROUP =>
           Left(AstError(p.position, "groups are not supported"))
         case FieldDescriptorProto.Type.TYPE_ENUM => {
@@ -242,8 +242,8 @@ private[scalapb] object AstUtils {
     def fieldGroupToValue(
         name: String,
         group: Seq[TField]
-    ): Either[AstError, (FieldDescriptor, PValue)] = {
-      val fd: FieldDescriptor                      = fieldMap(name)
+      ): Either[AstError, (FieldDescriptor, PValue)] = {
+      val fd: FieldDescriptor = fieldMap(name)
       val values: Either[AstError, Vector[PValue]] = flatten(group.map(pfieldToValue(fd, _)))
 
       values.map { (t: Seq[PValue]) =>
@@ -251,7 +251,7 @@ private[scalapb] object AstUtils {
         else
           fd -> PRepeated(t.foldLeft(Vector[PValue]()) {
             case (xs, PRepeated(ys)) => xs ++ ys
-            case (xs, t: PValue)     => xs :+ t
+            case (xs, t: PValue) => xs :+ t
           })
       }
     }
@@ -259,7 +259,7 @@ private[scalapb] object AstUtils {
     val maybeMap: Either[AstError, Vector[(FieldDescriptor, PValue)]] =
       ast.fields.find(f => !fieldMap.contains(f.name)) match {
         case Some(f) => Left(AstError(f.position, s"Unknown field name '${f.name}'"))
-        case None    => flatten(fields.map((fieldGroupToValue _).tupled).toVector)
+        case None => flatten(fields.map((fieldGroupToValue _).tupled).toVector)
       }
     maybeMap.map(t => PMessage(t.toMap))
   }

--- a/scalapb-runtime/src/main/scala/scalapb/textformat/TextFormatUtils.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/textformat/TextFormatUtils.scala
@@ -1,7 +1,7 @@
 package scalapb.textformat
 
 import java.math.BigInteger
-
+import scalapb.internal.compat._
 import com.google.protobuf.ByteString
 import scalapb.TextFormatError
 
@@ -49,9 +49,9 @@ private[scalapb] object TextFormatUtils {
       case CH_SLASH_R => sb.append("\\r")
       case CH_SLASH_T => sb.append("\\t")
       case CH_SLASH_V => sb.append("\\v")
-      case CH_SLASH   => sb.append("\\\\")
-      case CH_SQ      => sb.append("\\\'")
-      case CH_DQ      => sb.append("\\\"")
+      case CH_SLASH => sb.append("\\\\")
+      case CH_SQ => sb.append("\\\'")
+      case CH_DQ => sb.append("\\\"")
       case b if b >= 0x20 =>
         sb.append(b.toChar)
       case b =>
@@ -74,9 +74,9 @@ private[scalapb] object TextFormatUtils {
 
   def unescapeBytes(
       charString: String
-  ): Either[TextFormatError, ByteString] with Product with Serializable = {
+    ): Either[TextFormatError, ByteString] with Product with Serializable = {
     val input: ByteString = ByteString.copyFromUtf8(charString)
-    val result            = mutable.ArrayBuilder.make[Byte]
+    val result = mutable.ArrayBuilder.make[Byte]
     result.sizeHint(input.size)
 
     def defaultHandle(b: Byte) = {
@@ -89,21 +89,21 @@ private[scalapb] object TextFormatUtils {
 
     val endState = input.foldLeft[ByteParsingState](Default) { (state, b) =>
       (state, b) match {
-        case (e: Error, _)                           => e
-        case (Default, b)                            => defaultHandle(b)
+        case (e: Error, _) => e
+        case (Default, b) => defaultHandle(b)
         case (EscapeMode, b) if b >= '0' && b <= '7' => Octal1(digitValue(b))
-        case (EscapeMode, CH_A)                      => result += 7; Default
-        case (EscapeMode, CH_B)                      => result += '\b'; Default
-        case (EscapeMode, CH_F)                      => result += '\f'; Default
-        case (EscapeMode, CH_N)                      => result += '\n'; Default
-        case (EscapeMode, CH_R)                      => result += '\r'; Default
-        case (EscapeMode, CH_T)                      => result += '\t'; Default
-        case (EscapeMode, CH_V)                      => result += 11; Default
-        case (EscapeMode, CH_SLASH)                  => result += '\\'; Default
-        case (EscapeMode, CH_SQ)                     => result += '\''; Default
-        case (EscapeMode, CH_DQ)                     => result += '\"'; Default
-        case (EscapeMode, CH_X)                      => Hex0
-        case (EscapeMode, _)                         => Error("Invalid escape sequence: " + b.toChar)
+        case (EscapeMode, CH_A) => result += 7; Default
+        case (EscapeMode, CH_B) => result += '\b'; Default
+        case (EscapeMode, CH_F) => result += '\f'; Default
+        case (EscapeMode, CH_N) => result += '\n'; Default
+        case (EscapeMode, CH_R) => result += '\r'; Default
+        case (EscapeMode, CH_T) => result += '\t'; Default
+        case (EscapeMode, CH_V) => result += 11; Default
+        case (EscapeMode, CH_SLASH) => result += '\\'; Default
+        case (EscapeMode, CH_SQ) => result += '\''; Default
+        case (EscapeMode, CH_DQ) => result += '\"'; Default
+        case (EscapeMode, CH_X) => Hex0
+        case (EscapeMode, _) => Error("Invalid escape sequence: " + b.toChar)
         case (Octal1(i), b) if b >= '0' && b <= '7' =>
           Octal2(i * 8 + digitValue(b))
         case (Octal1(i), b) =>
@@ -115,9 +115,9 @@ private[scalapb] object TextFormatUtils {
         case (Octal2(i), b) =>
           result += i.toByte
           defaultHandle(b)
-        case (Hex0, b) if (isHexDigit(b.toChar)) => Hex1(digitValue(b))
-        case (Hex0, _)                           => Error("'\\x' with no digits")
-        case (Hex1(i), b) if (isHexDigit(b.toChar)) =>
+        case (Hex0, b) if isHexDigit(b.toChar) => Hex1(digitValue(b))
+        case (Hex0, _) => Error("'\\x' with no digits")
+        case (Hex1(i), b) if isHexDigit(b.toChar) =>
           result += (16 * i + digitValue(b)).toByte
           Default
         case (Hex1(i), b) =>
@@ -127,8 +127,8 @@ private[scalapb] object TextFormatUtils {
     }
 
     endState match {
-      case Error(e)   => Left(TextFormatError(e))
-      case Hex0       => Left(TextFormatError("'\\x' with no digits"))
+      case Error(e) => Left(TextFormatError(e))
+      case Hex0 => Left(TextFormatError("'\\x' with no digits"))
       case EscapeMode => Left(TextFormatError("Invalid escape sequence '\\' at end of string."))
       case Hex1(i) =>
         result += i.toByte


### PR DESCRIPTION
Dear, 

We really like the custom type feature of scalapb but our build has become overly complex because the lack of scala 2.11 support and the incompatible code generation between 0.9 and 0.11. 

So i tried cross-building the scalapb runtime to 2.11 and it isn't that hard to add support.

Are you interested in this feature? 
Was there any specific reason to drop 2.11 support?
