### PR TITLE
Update protobufCompilerVersion to 0.19.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.tools.mima.core._
 import BuildHelper._
 import Dependencies._
 
-val protobufCompilerVersion = "3.15.8"
+val protobufCompilerVersion = "3.19.1"
 
 val MimaPreviousVersion = "0.11.0"
 


### PR DESCRIPTION
Hi, we've found out ScalaPB uses quite an old version of the Protobuf compiler. Unless there's a strong reason why it does so, please accept this PR with a version update (and release a new ScalaPB version after that 😇).  
Thanks!