### PR TITLE
Update .scala-steward.conf to ignore scala3-library_sjs1-3.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,5 +3,6 @@ updates.ignore = [
   { groupId = "com.github.os72", artifactId = "protoc-jar" },
   { groupId = "com.google.protobuf" },
   { groupId = "org.scala-lang", artifactId = "scala3-compiler", version = { prefix = "3.1." } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = { prefix = "3.1." } }
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = { prefix = "3.1." } },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { prefix = "3.1." } }
 ]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   // NOTE: Scala 3 versions are not forward-compatible across minor versions. To allow
   // maximal compatibility for end-users Scala 3 version needs to be kept on 3.0.x.
-  val Scala3 = "3.1.1"
+  val Scala3 = "3.0.2"
 
   val silencer = Seq(
     sbt.compilerPlugin(


### PR DESCRIPTION
After original attempt to ignore Scala 3.1 https://github.com/scalapb/ScalaPB/pull/1326 Steward suggested to ignore scala3-library_sjs1 as well https://github.com/scalapb/ScalaPB/pull/1327