### PR TITLE
adding stub factory for clients

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -286,7 +286,9 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       .newline
       .add(s"object ${service.name}StubFactory extends $stubFactory[${service.stub}] { ")
       .indent
-      .add(s"override def newStub(channel: $channel, options: $callOptions) = new ${service.stub}(channel, options)")
+      .add(
+        s"override def newStub(channel: $channel, options: $callOptions) = new ${service.stub}(channel, options)"
+      )
       .outdent
       .add("}")
       .newline

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GrpcServicePrinter.scala
@@ -81,6 +81,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
   private[this] val callOptions = "_root_.io.grpc.CallOptions"
 
   private[this] val abstractStub   = "_root_.io.grpc.stub.AbstractStub"
+  private[this] val stubFactory    = "_root_.io.grpc.stub.AbstractStub.StubFactory"
   private[this] val streamObserver = "_root_.io.grpc.stub.StreamObserver"
 
   private[this] val serverCalls = "_root_.io.grpc.stub.ServerCalls"
@@ -282,6 +283,12 @@ final class GrpcServicePrinter(service: ServiceDescriptor, implicits: Descriptor
       )
       .newline
       .add(s"def stub(channel: $channel): ${service.stub} = new ${service.stub}(channel)")
+      .newline
+      .add(s"object ${service.name}StubFactory extends $stubFactory[${service.stub}] { ")
+      .indent
+      .add(s"override def newStub(channel: $channel, options: $callOptions) = new ${service.stub}(channel, options)")
+      .outdent
+      .add("}")
       .newline
       .add(
         s"def javaDescriptor: _root_.com.google.protobuf.Descriptors.ServiceDescriptor = ${service.javaDescriptorSource}"

--- a/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -213,8 +213,8 @@ class GrpcServiceScalaServerSpec extends GrpcServiceSpecBase {
 
       it("companion object acts as stub factory") {
         withScalaServer { channel =>
-          Service1GrpcScala.Service1.newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
-          implicitly[StubFactory[Service1GrpcScala.Service1]].newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
+          Service1GrpcScala.Service1Stub.newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
+          implicitly[StubFactory[Service1GrpcScala.Service1Stub]].newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
         }
 
       }

--- a/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -213,8 +213,8 @@ class GrpcServiceScalaServerSpec extends GrpcServiceSpecBase {
 
       it("companion object acts as stub factory") {
         withScalaServer { channel =>
-          Service1GrpcScala.Service1Stub.newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
-          implicitly[StubFactory[Service1GrpcScala.Service1Stub]].newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
+          Service1GrpcScala.Service1Stub.newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1Stub]
+          implicitly[StubFactory[Service1GrpcScala.Service1Stub]].newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1Stub]
         }
 
       }

--- a/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -1,4 +1,5 @@
 import io.grpc.CallOptions
+import io.grpc.stub.AbstractStub.StubFactory
 import io.grpc.reflection.v1alpha.reflection._
 import io.grpc.reflection.v1alpha.reflection.ServerReflectionRequest.MessageRequest
 

--- a/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceScalaServerSpec.scala
@@ -1,5 +1,7 @@
+import io.grpc.CallOptions
 import io.grpc.reflection.v1alpha.reflection._
 import io.grpc.reflection.v1alpha.reflection.ServerReflectionRequest.MessageRequest
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
@@ -206,6 +208,14 @@ class GrpcServiceScalaServerSpec extends GrpcServiceSpecBase {
           requestObserver.onCompleted()
           Await.result(future, 2.seconds) must be(Vector(Res1(17), Res2(3), Res1(17), Res2(3)))
         }
+      }
+
+      it("companion object acts as stub factory") {
+        withScalaServer { channel =>
+          Service1GrpcScala.Service1.newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
+          implicitly[StubFactory[Service1GrpcScala.Service1]].newStub(channel, CallOptions.DEFAULT) mustBe a[Service1GrpcScala.Service1]
+        }
+
       }
 
     }


### PR DESCRIPTION
This adds a stub factory to the client API.
I did it quick and dirty just to get the point across - I would gladly make changes.

I did not add tests since I wasn't sure how and where to add them - advice on that would be most welcome.

I decided to add an object but this can also be in a companion object or just on the main definition of the Grpc object.

Thanks for considering!