### PR TITLE
Support transformation on repeated option scalar

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/FieldTransformations.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/FieldTransformations.scala
@@ -95,7 +95,10 @@ private[compiler] object FieldTransformations {
     pattern.forall { case (fd, v) =>
       if (!fd.isExtension()) {
         if (fd.getType() != Type.MESSAGE)
-          input.hasField(fd) && input.getField(fd) == v
+          if (fd.isRepeated) {
+            input.getRepeatedFieldCount(fd) > 0 && input.getField(fd) == v
+          } else
+            input.hasField(fd) && input.getField(fd) == v
         else {
           input.hasField(fd) && matchContains(
             input.getField(fd).asInstanceOf[Message],
@@ -122,7 +125,11 @@ private[compiler] object FieldTransformations {
     pattern.forall { case (fd, v) =>
       if (!fd.isExtension()) {
         if (fd.getType() != Type.MESSAGE)
-          input.hasField(fd)
+          if (fd.isRepeated) {
+            input.getRepeatedFieldCount(fd) > 0
+          } else {
+            input.hasField(fd)
+          }
         else {
           input.hasField(fd) && matchPresence(
             input.getField(fd).asInstanceOf[Message],

--- a/compiler-plugin/src/test/scala/scalapb/compiler/FieldTransformationsSpec.scala
+++ b/compiler-plugin/src/test/scala/scalapb/compiler/FieldTransformationsSpec.scala
@@ -37,6 +37,7 @@ class FieldTransformationsSpec extends AnyFlatSpec with Matchers with ProtocInvo
          |}
          |message StringRules {
          |  optional string const = 1;
+         |  repeated string in = 2;
          |}
          |extend google.protobuf.FieldOptions {
          |  optional FieldRules rules = 50001;
@@ -465,6 +466,26 @@ class FieldTransformationsSpec extends AnyFlatSpec with Matchers with ProtocInvo
       msg = "",
       pattern = "int32: {gt: 0}"
     ) must be(false)
+
+    matchContains(
+      msg = """string: {in: ["a", "b"]}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(true)
+
+    matchContains(
+      msg = """string: {in: ["a", "b", "c"]}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(false)
+
+    matchContains(
+      msg = """string: {in: ["a"]}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(false)
+
+    matchContains(
+      msg = """string: {const: "a"}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(false)
   }
 
   "matchPresence" must "match correctly" in {
@@ -512,6 +533,26 @@ class FieldTransformationsSpec extends AnyFlatSpec with Matchers with ProtocInvo
       msg = "int32: {gt: 0, lt: 0}",
       pattern = "int32: {gt: 0}"
     ) must be(true)
+
+    matchPresence(
+      msg = """string: {in: ["a", "b", "c"]}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(true)
+
+    matchPresence(
+      msg = """string: {in: ["a"]}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(true)
+
+    matchPresence(
+      msg = """string: {in: []}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(false)
+
+    matchPresence(
+      msg = """string: {const: "a"}""",
+      pattern = """string: {in: ["a", "b"]}"""
+    ) must be(false)
   }
 
   def fieldByPath(fo: FieldDescriptorProto, path: String) =

--- a/docs/src/main/markdown/transformations.md
+++ b/docs/src/main/markdown/transformations.md
@@ -117,9 +117,9 @@ option (when `scope: PACKAGE` option is set).
 A field transformation matches on the `when` condition which a [FieldDescriptorProto](https://github.com/protocolbuffers/protobuf/blob/48234f5f012582843bb476ee3afef36cda94cb66/src/google/protobuf/descriptor.proto#L138-L239). This allows it to match on the field's type, or label (`LABEL_REPEATED`, `LABEL_OPTIONAL`, `LABEL_REQUIRED`), as well as on custom options like in the previous example. There are few matching modes that are described below and can be selected using `match_type`. The `set` field tells ScalaPB what options to apply to the field if the rule conditions match. Currently, only `[scalapb.field]` options  may appear in the `set` field.
 
 There are three matching modes available:
-* `CONTAINS` is the default matching mode. In this mode, ScalaPB checks that all the options in the `when` pattern are defined on the field descriptor and having the same value. Additional fields may be defined on the field besides the ones on the `when` pattern.
+* `CONTAINS` is the default matching mode. In this mode, ScalaPB checks that all the options in the `when` pattern are defined on the field descriptor and having the same value (even if the field is repeated). Additional fields may be defined on the field besides the ones on the `when` pattern.
 * `EXACT` is a strict equality comparison between the `when` pattern and the field descriptor.
-* `PRESENCE` checks whether every field that is present on the `when` pattern is also present on the field's rules. The specific value the option has is not compared. This allows matching on any value. For example, `{int32: {gt: 1}}` would match for any number assigned to `int32.gt`.
+* `PRESENCE` checks whether every field that is present on the `when` pattern is also present on the field's rules. The specific value the option has is not compared. This allows matching on any value. For example, `{int32: {gt: 1}}` would match for any number assigned to `int32.gt`. For repeated fields, `PRESENCE` verifies that the value is not empty. 
 
 ### Referencing rules values
 


### PR DESCRIPTION
Solves partially https://github.com/scalapb/ScalaPB/issues/1177 because it only add supports for scalar and not messages.
However it's enough for supporting `protoc-gen-validate` options.