### PR TITLE
Build for Scala Native, Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val runtime = (projectMatrix in file("scalapb-runtime"))
     )
   )
   .nativePlatform(
-    scalaVersions = Seq(Scala212, Scala213),
+    scalaVersions = Seq(Scala212, Scala213, Scala3),
     settings = sharedNativeSettings ++ Seq(
       libraryDependencies += protobufRuntimeScala.value,
       Compile / unmanagedResourceDirectories += (LocalRootProject / baseDirectory).value / "third_party",
@@ -278,7 +278,7 @@ lazy val lenses = (projectMatrix in file("lenses"))
     )
   )
   .nativePlatform(
-    scalaVersions = Seq(Scala212, Scala213),
+    scalaVersions = Seq(Scala212, Scala213, Scala3),
     settings = sharedNativeSettings
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val annotationApi           = "1.3.2"
     val cats                    = "2.6.1"
     val mockito                 = "4.6.1"
-    val munit                   = "0.7.29"
+    val munit                   = "1.0.0-M6"
     val scalaTest               = "3.2.13"
     val scalaTestPlusMockito    = "3.1.0.0"
     val scalaTestPlusScalaCheck = "3.2.11.0"


### PR DESCRIPTION
Since 0.4.4, Scala Native supports Scala 3.

The update to the munit testing library was necessary because the 0.x series does not support Scala Native on 3 ( see for a discussion https://github.com/scalameta/munit/pull/511).