### PR TITLE
Bump protobuf-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 import BuildHelper._
 import Dependencies._
 
-val protobufCompilerVersion = "3.19.6"
+val protobufCompilerVersion = "3.21.12"
 
 val MimaPreviousVersion = "0.11.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import Keys._
 object Dependencies {
   object versions {
     val grpc                 = "1.47.1"
-    val protobuf             = "3.19.6"
+    val protobuf             = "3.21.12"
     val silencer             = "1.7.12"
     val collectionCompat     = "2.9.0"
     val coursier             = "2.0.16"


### PR DESCRIPTION
I was trying to get the latest zio grpc work with the latest scalapb but it seems like the `protobuf-java` version is not in sync and it is throwing a `NoSuchMethod` exception somewhere as the `parseUnknownField` has only been recently introduced (I believe due to security issues)