### PR TITLE
[WIP] Add scala.annotation.nowarn to deprecated annotation list

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -352,36 +352,6 @@ class DescriptorImplicits private[compiler] (
       deprecated ++ fieldOptions.getAnnotationsList().asScala.toSeq
     }
 
-    def deprecatedAnnotation: String =
-      if (fd.getOptions.getDeprecated) {
-        // for field descriptors only need to use nowarn as adding a @deprecation annotation will propagate
-        //  the warnings if this field is used on the right of the assignment operator (=)
-        //  ex. ```
-        // @scala.annotation.nowarn(..) @scala.deprecated(...)
-        //  val value = someVariableThatIsDeprecated
-        //  ```
-        //  will cause references to `value` to produce warnings
-        """@scala.annotation.nowarn("cat=deprecation")"""
-      } else {
-        ""
-      }
-
-    def referenceAnnotations: String =
-      if (fd.getOptions.getDeprecated) {
-        // todo: for field descriptors only need to use nowarn as adding a @deprecation annotation will propagate
-        //  the warnings if this field is used on the right of the assignment operator (=)
-        //  ex. ```
-        // @scala.annotation.nowarn(..) @ todo
-        //  val value = someVariableThatIsDeprecated
-        //  ```
-        // ProtobufGenerator.deprecatedAnnotation.mkString(
-        //   ExtendedDescriptorConstants.AnnotationSeparator
-        // )
-        """@scala.annotation.nowarn("cat=deprecation")"""
-      } else {
-        ""
-      }
-
     def customSingleScalaTypeName: Option[String] = {
       // If the current message is within a MapEntry (that is a key, or a value), find the actual map
       // field in the enclosing message. This is used to determine map level options when processing the
@@ -581,10 +551,12 @@ class DescriptorImplicits private[compiler] (
     else message.getFile.noDefaultValuesInConstructor
 
     private[this] def deprecatedAnnotation: Seq[String] = {
-      val hasDeprecatedField = message.fields.exists(_.getOptions.getDeprecated)
-      if (message.getOptions.getDeprecated || hasDeprecatedField)
+      lazy val hasDeprecatedField = message.fields.exists(_.getOptions.getDeprecated)
+      if (message.getOptions.getDeprecated)
         // either the message is deprecated or it has a field that is
         ProtobufGenerator.deprecatedAnnotation
+      else if (hasDeprecatedField)
+        Seq(ProtobufGenerator.nowarnAnnotation())
       else
         Nil
     }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -77,6 +77,10 @@ class DescriptorImplicits private[compiler] (
   private[scalapb] lazy val fileOptionsCache =
     FileOptionsCache.buildCache(files, secondaryOutputsProvider)
 
+  object ExtendedDescriptorConstants {
+    val AnnotationSeparator = " "
+  }
+
   implicit final class ExtendedMethodDescriptor(method: MethodDescriptor) {
     class MethodTypeWrapper(descriptor: Descriptor) {
       def customScalaType: Option[String] =
@@ -136,13 +140,14 @@ class DescriptorImplicits private[compiler] (
         .filter(_.nonEmpty)
     }
 
-    def deprecatedAnnotation: String = {
+    def deprecatedAnnotation: String =
       if (method.getOptions.getDeprecated) {
-        ProtobufGenerator.deprecatedAnnotation + " "
+        ProtobufGenerator.deprecatedAnnotation.mkString(
+          ExtendedDescriptorConstants.AnnotationSeparator
+        )
       } else {
         ""
       }
-    }
 
     def javaDescriptorSource: String =
       s"${method.getService.javaDescriptorSource}.getMethods().get(${method.getIndex})"
@@ -185,13 +190,14 @@ class DescriptorImplicits private[compiler] (
         .filter(_.nonEmpty)
     }
 
-    def deprecatedAnnotation: String = {
+    def deprecatedAnnotation: String =
       if (self.getOptions.getDeprecated) {
-        ProtobufGenerator.deprecatedAnnotation + " "
+        ProtobufGenerator.deprecatedAnnotation.mkString(
+          ExtendedDescriptorConstants.AnnotationSeparator
+        )
       } else {
         ""
       }
-    }
   }
 
   implicit class ExtendedFieldDescriptor(val fd: FieldDescriptor) {
@@ -339,7 +345,7 @@ class DescriptorImplicits private[compiler] (
     def annotationList: Seq[String] = {
       val deprecated = {
         if (fd.getOptions.getDeprecated)
-          List(ProtobufGenerator.deprecatedAnnotation)
+          ProtobufGenerator.deprecatedAnnotation
         else
           Nil
       }
@@ -546,7 +552,7 @@ class DescriptorImplicits private[compiler] (
 
     private[this] def deprecatedAnnotation: Seq[String] = {
       if (message.getOptions.getDeprecated)
-        List(ProtobufGenerator.deprecatedAnnotation)
+        ProtobufGenerator.deprecatedAnnotation
       else
         Nil
     }
@@ -836,7 +842,7 @@ class DescriptorImplicits private[compiler] (
 
     private[this] def deprecatedAnnotation: Seq[String] = {
       if (enumDescriptor.getOptions.getDeprecated)
-        List(ProtobufGenerator.deprecatedAnnotation)
+        ProtobufGenerator.deprecatedAnnotation
       else
         Nil
     }
@@ -906,7 +912,7 @@ class DescriptorImplicits private[compiler] (
 
     private[this] def deprecatedAnnotation: Seq[String] = {
       if (enumValue.getOptions.getDeprecated)
-        List(ProtobufGenerator.deprecatedAnnotation)
+        ProtobufGenerator.deprecatedAnnotation
       else
         Nil
     }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -27,7 +27,7 @@ class ProtobufGenerator(
     val name = e.scalaType.nameSymbol
     printer
       .when(e.getOptions.getDeprecated) {
-        _.add(ProtobufGenerator.deprecatedAnnotation)
+        _.add(ProtobufGenerator.deprecatedAnnotation: _*)
       }
       .call(generateScalaDoc(e))
       .seq(e.baseAnnotationList)
@@ -47,7 +47,7 @@ class ProtobufGenerator(
       .add("}")
       .add("")
       .when(e.getOptions.getDeprecated) {
-        _.add(ProtobufGenerator.deprecatedAnnotation)
+        _.add(ProtobufGenerator.deprecatedAnnotation: _*)
       }
       .add(s"object $name extends ${e.companionExtends.mkString(" with ")} {")
       .indent
@@ -1731,8 +1731,11 @@ object ProtobufGenerator {
     } else contentLines
   }
 
-  val deprecatedAnnotation: String =
-    """@scala.annotation.nowarn("cat=deprecation") @scala.deprecated(message="Marked as deprecated in proto file", "")"""
+  val deprecatedAnnotation: Seq[String] =
+    Seq(
+      """@scala.annotation.nowarn("cat=deprecation")""",
+      """@scala.deprecated(message="Marked as deprecated in proto file", "")"""
+    )
 
   private val CompSeqType =
     "Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]]"

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -358,7 +358,10 @@ class ProtobufGenerator(
             // In proto3, drop default value
             fp.add(s"case ${f.getNumber} => {")
               .indent
-              .add(s"val __t = $e")
+              .add(s"""
+                      |${f.referenceAnnotations}
+                      |val __t = $e
+              """.stripMargin)
               .add({
                 val cond =
                   if (!f.isEnum)
@@ -369,7 +372,10 @@ class ProtobufGenerator(
               })
               .outdent
               .add("}")
-          } else fp.add(s"case ${f.getNumber} => $e")
+          } else fp.add(s"""
+                           |${f.referenceAnnotations}
+                           |case ${f.getNumber} => $e
+          """.stripMargin)
         }
         .outdent
         .add("}")
@@ -394,8 +400,18 @@ class ProtobufGenerator(
   }
 
   def generateGetFieldPValue(message: Descriptor)(fp: FunctionalPrinter) = {
+    // if `message` has 1 or more deprecated fields, just retrieve one FieldDescriptor to populate the deprecatedAnnotations
+    // this is general, for generating any method where we want to produce annotations at the method-signature level
+    val anyDeprecatedField: Option[FieldDescriptor] =
+      message.fields.find(_.getOptions.getDeprecated)
+    val methodAnnotations: String = anyDeprecatedField.map(_.deprecatedAnnotation).getOrElse("")
+
     val signature =
-      "def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = "
+      s"""
+         |${methodAnnotations}
+         |def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = 
+      """.stripMargin
+
     if (message.fields.nonEmpty)
       fp.add(signature + "{")
         .indent
@@ -493,15 +509,19 @@ class ProtobufGenerator(
     val fieldNameSymbol = fieldAccessorSymbol(field)
 
     if (field.isRequired || field.noBoxRequired) {
-      fp.add(s"""
-                |{
-                |  val __value = ${toBaseType(field)(fieldNameSymbol)}
-                |  __size += ${sizeExpressionForSingleField(field, "__value")}
-                |};""".stripMargin)
+      fp.add(
+        s"""
+           |{
+           |  ${field.referenceAnnotations} 
+           |  val __value = ${toBaseType(field)(fieldNameSymbol)}
+           |  __size += ${sizeExpressionForSingleField(field, "__value")}
+           |};""".stripMargin
+      )
     } else if (field.isSingular) {
       fp.add(
         s"""
            |{
+           |  ${field.referenceAnnotations}
            |  val __value = ${toBaseType(field)(fieldNameSymbol)}
            |  if (${isNonEmpty("__value", field)}) {
            |    __size += ${sizeExpressionForSingleField(field, "__value")}
@@ -511,7 +531,10 @@ class ProtobufGenerator(
     } else if (field.isOptional) {
       fp.add(
         s"""if ($fieldNameSymbol.isDefined) {
-           |  val __value = ${toBaseType(field)(fieldNameSymbol + ".get")}
+           |  ${field.referenceAnnotations}
+           |  val __value = ${toBaseType(field)(
+            fieldNameSymbol + ".get"
+          )}
            |  __size += ${sizeExpressionForSingleField(field, "__value")}
            |};""".stripMargin
       )
@@ -525,6 +548,7 @@ class ProtobufGenerator(
             )
           case None =>
             fp.add(s"""${field.collection.foreach} { __item =>
+                      |  ${field.referenceAnnotations}
                       |  val __value = ${toBaseType(field)("__item")}
                       |  __size += ${sizeExpressionForSingleField(field, "__value")}
                       |}""".stripMargin)
@@ -533,6 +557,7 @@ class ProtobufGenerator(
         val fieldName = field.scalaName
         fp.add(
           s"""if (${field.collection.nonEmptyCheck(fieldNameSymbol)}) {
+             |  ${field.referenceAnnotations}
              |  val __localsize = ${fieldName}SerializedSize
              |  __size += $tagSize + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__localsize) + __localsize
              |}""".stripMargin
@@ -655,7 +680,7 @@ class ProtobufGenerator(
             .add("")
             .add("{")
             .indent
-            .add(s"val __v = ${toBaseType(field)(fieldNameSymbol)}")
+            .add(s"${field.referenceAnnotations} val __v = ${toBaseType(field)(fieldNameSymbol)}")
             .call(generateWriteSingleValue(field, "__v"))
             .outdent
             .add("};")
@@ -665,7 +690,7 @@ class ProtobufGenerator(
           printer
             .add(s"{")
             .indent
-            .add(s"val __v = ${toBaseType(field)(fieldNameSymbol)}")
+            .add(s"${field.referenceAnnotations} val __v = ${toBaseType(field)(fieldNameSymbol)}")
             .add(s"if (${isNonEmpty("__v", field)}) {")
             .indent
             .call(generateWriteSingleValue(field, "__v"))
@@ -941,28 +966,42 @@ class ProtobufGenerator(
             val optionLensName = "optional" + field.upperScalaName
             printer
               .add(
-                s"""def $fieldName: ${lensType(
+                s"""
+                   |${field.referenceAnnotations}
+                   |def $fieldName: ${lensType(
                     field.singleScalaTypeName
                   )} = field(_.${field.getMethod})((c_, f_) => c_.copy($fieldName = Option(f_)))
+                   |${field.referenceAnnotations}
                    |def ${optionLensName}: ${lensType(
                     field.scalaTypeName
                   )} = field(_.$fieldName)((c_, f_) => c_.copy($fieldName = f_))""".stripMargin
               )
           } else
             printer.add(
-              s"def $fieldName: ${lensType(field.scalaTypeName)} = field(_.$fieldName)((c_, f_) => c_.copy($fieldName = f_))"
+              s"""
+                 |${field.referenceAnnotations}
+                 |def $fieldName: ${lensType(
+                  field.scalaTypeName
+                )} = field(_.$fieldName)((c_, f_) => c_.copy($fieldName = f_))
+              """.stripMargin
             )
         } else {
           val oneofName = field.getContainingOneof.scalaName.nameSymbol
           printer
             .add(
-              s"def $fieldName: ${lensType(field.scalaTypeName)} = field(_.${field.getMethod})((c_, f_) => c_.copy($oneofName = ${field.oneOfTypeName
-                  .fullNameWithMaybeRoot(message)}(f_)))"
+              s"""
+                 |${field.referenceAnnotations}
+                 |def $fieldName: ${lensType(
+                  field.scalaTypeName
+                )} = field(_.${field.getMethod})((c_, f_) => c_.copy($oneofName = ${field.oneOfTypeName
+                  .fullNameWithMaybeRoot(message)}(f_)))
+              """.stripMargin
             )
         }
       }
       .print(message.getRealOneofs.asScala) { case (printer, oneof) =>
         val oneofName = oneof.scalaName.nameSymbol
+        // todo
         printer
           .add(
             s"def $oneofName: ${lensType(oneof.scalaType.fullNameWithMaybeRoot(message))} = field(_.$oneofName)((c_, f_) => c_.copy($oneofName = f_))"

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -1732,7 +1732,7 @@ object ProtobufGenerator {
   }
 
   val deprecatedAnnotation: String =
-    """@scala.deprecated(message="Marked as deprecated in proto file", "")"""
+    """@scala.annotation.nowarn("cat=deprecation") @scala.deprecated(message="Marked as deprecated in proto file", "")"""
 
   private val CompSeqType =
     "Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]]"

--- a/compiler-plugin/src/test/scala/scalapb/compiler/DescriptorImplicitsSpec.scala
+++ b/compiler-plugin/src/test/scala/scalapb/compiler/DescriptorImplicitsSpec.scala
@@ -69,7 +69,8 @@ class DescriptorImplicitsSpec extends AnyFlatSpec with Matchers with ProtocInvoc
       .findMessageTypeByName("D")
       .annotationList must be(
       Seq(
-        """@scala.annotation.nowarn("cat=deprecation") @scala.deprecated(message="Marked as deprecated in proto file", "")"""
+        """@scala.annotation.nowarn("cat=deprecation")""",
+        """@scala.deprecated(message="Marked as deprecated in proto file", "")"""
       )
     )
 
@@ -80,7 +81,8 @@ class DescriptorImplicitsSpec extends AnyFlatSpec with Matchers with ProtocInvoc
       .findFieldByNumber(1)
       .annotationList must be(
       Seq(
-        """@scala.annotation.nowarn("cat=deprecation") @scala.deprecated(message="Marked as deprecated in proto file", "")"""
+        """@scala.annotation.nowarn("cat=deprecation")""",
+        """@scala.deprecated(message="Marked as deprecated in proto file", "")"""
       )
     )
   }


### PR DESCRIPTION
# TODO
- [x] see Tests section below, there are other spots where the generated code is referencing the deprecated field and so additional changes are required.
- [ ] Add test for class annotations
- [ ] Test OneOf
- [ ] Test Enum
- [ ] run `./make_plugin.proto.sh`

## Changes
- adds `scala.annotation.nowarn` when a Message or Field is annotated with `deprecated`
- reference: https://github.com/scalapb/ScalaPB/issues/550#issuecomment-1407062978


## Tests:
using the following protobuf:
```protobuf
syntax = "proto3";

package tutorial;

message SomeTest {
  string test = 2 [deprecated = true];
}
```

The result and compile warnings are:

on `0.11.1`:
```
@SerialVersionUID(0L)
final case class SomeTest(
    @scala.deprecated(message="Marked as deprecated in proto file", "") test: _root_.scala.Predef.String = "",
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[SomeTest] { ... }

[warn] 7 deprecations; re-run with -deprecation for details
[warn] one warning found

[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:19:23: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]         val __value = test
[warn]                       ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:37:19: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]         val __v = test
[warn]                   ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:50:21: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]           val __t = test
[warn]                     ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:58:54: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]         case 2 => _root_.scalapb.descriptors.PString(test)
[warn]                                                      ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:10:73: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]     @scala.deprecated(message="Marked as deprecated in proto file", "") test: _root_.scala.Predef.String = "",
[warn]                                                                         ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:9:18: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn] final case class SomeTest(
[warn]                  ^
[warn] /Users/mloyzer/workspace/mark/ScalaPB/examples/basic/target/scala-2.13/src_managed/main/scalapb/tutorial/addressbookv3/SomeTest.scala:107:89: value test in class SomeTest is deprecated: Marked as deprecated in proto file
[warn]     def test: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.test)((c_, f_) => c_.copy(test = f_))
[warn]                                                                                         ^
[warn] 7 warnings found
```


on SNAPSHOT:
```
@scala.annotation.nowarn("cat=deprecation")
@SerialVersionUID(0L)
final case class SomeTest(
    @scala.annotation.nowarn("cat=deprecation") @scala.deprecated(
      message = "Marked as deprecated in proto file",
      ""
    ) test: _root_.scala.Predef.String = "",
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[SomeTest] { ... }

<no warns>
```