### PR TITLE
Add http4s-grpc

### DIFF
--- a/docs/src/main/markdown/grpc.md
+++ b/docs/src/main/markdown/grpc.md
@@ -15,6 +15,7 @@ There are additional gRPC libraries built on top of ScalaPB that provide integra
   servers and clients using ZIO.
 * [fs2-grpc](https://github.com/typelevel/fs2-grpc) provides gGRPC support for FS2 and Cats Effect.
 * [Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/index.html) provides support for building streaming gRPC servers and clients on top of Akka Streams and Akka HTTP.
+* [http4s-grpc](https://github.com/davenverse/http4s-grpc) enables you to build gRPC clients and servers with Cats Effect and FS2. It is implemented on top of http4s Ember and runs on JVM, Node.js, and Scala Native.
 
 ## Project Setup
 


### PR DESCRIPTION
Adds http4s-grpc to the list of gRPC implementations. This is a new project, so still early days, but we are looking for users and feedback!