### PR TITLE
MethodDescriptor: add input and output types

### DIFF
--- a/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
+++ b/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
@@ -1,0 +1,18 @@
+import com.thesamet.proto.e2e.service.{Res5, Service1Grpc}
+import com.thesamet.proto.e2e.type_level.XYMessage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.{LoneElement, OptionValues}
+import scalapb.descriptors.ScalaType
+
+class MethodDescriptorSpec extends AnyFlatSpec with Matchers with LoneElement with OptionValues {
+
+  "scala descriptor" must "expose correct input and output message descriptors" in {
+    val unaryMethod = Service1Grpc.Service1.scalaDescriptor.methods.find(_.name == "CustomUnary").get
+    val inputDescriptor = XYMessage.scalaDescriptor
+    val outputDescriptor = Res5.scalaDescriptor
+
+    unaryMethod.inputType mustBe ScalaType.Message(inputDescriptor)
+    unaryMethod.outputType mustBe ScalaType.Message(outputDescriptor)
+  }
+}

--- a/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
+++ b/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
@@ -3,16 +3,13 @@ import com.thesamet.proto.e2e.type_level.XYMessage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{LoneElement, OptionValues}
-import scalapb.descriptors.ScalaType
 
 class MethodDescriptorSpec extends AnyFlatSpec with Matchers with LoneElement with OptionValues {
 
   "scala descriptor" must "expose correct input and output message descriptors" in {
     val unaryMethod = Service1Grpc.Service1.scalaDescriptor.methods.find(_.name == "CustomUnary").get
-    val inputDescriptor = XYMessage.scalaDescriptor
-    val outputDescriptor = Res5.scalaDescriptor
 
-    unaryMethod.inputType mustBe ScalaType.Message(inputDescriptor)
-    unaryMethod.outputType mustBe ScalaType.Message(outputDescriptor)
+    unaryMethod.inputType must be theSameInstanceAs XYMessage.scalaDescriptor
+    unaryMethod.outputType must be theSameInstanceAs Res5.scalaDescriptor
   }
 }

--- a/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
@@ -149,34 +149,30 @@ class MethodDescriptor private[descriptors] (
 
   def getOptions = asProto.getOptions
 
-  lazy val inputType: ScalaType = {
+  lazy val inputType: Descriptor = {
     val inputType = asProto.inputType.getOrElse(
       throw new DescriptorValidationException(this, "missing method input type")
     )
 
-    ScalaType.Message(
-      FileDescriptor
-        .find(containingService.file, this, inputType)
-        .getOrElse(
-          throw new DescriptorValidationException(this, "couldn't build input type descriptor")
-        )
-        .asInstanceOf[Descriptor]
-    )
+    FileDescriptor
+      .find(containingService.file, this, inputType)
+      .getOrElse(
+        throw new DescriptorValidationException(this, "couldn't build input type descriptor")
+      )
+      .asInstanceOf[Descriptor]
   }
 
-  lazy val outputType: ScalaType = {
+  lazy val outputType: Descriptor = {
     val outputType = asProto.outputType.getOrElse(
       throw new DescriptorValidationException(this, "missing method output type")
     )
 
-    ScalaType.Message(
-      FileDescriptor
-        .find(containingService.file, this, outputType)
-        .getOrElse(
-          throw new DescriptorValidationException(this, "couldn't build output type descriptor")
-        )
-        .asInstanceOf[Descriptor]
-    )
+    FileDescriptor
+      .find(containingService.file, this, outputType)
+      .getOrElse(
+        throw new DescriptorValidationException(this, "couldn't build output type descriptor")
+      )
+      .asInstanceOf[Descriptor]
   }
 }
 

--- a/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
@@ -148,6 +148,36 @@ class MethodDescriptor private[descriptors] (
   def location = containingService.file.findLocationByPath(SourceCodePath.get(this))
 
   def getOptions = asProto.getOptions
+
+  lazy val inputType: ScalaType = {
+    val inputType = asProto.inputType.getOrElse(
+      throw new DescriptorValidationException(this, "missing method input type")
+    )
+
+    ScalaType.Message(
+      FileDescriptor
+        .find(containingService.file, this, inputType)
+        .getOrElse(
+          throw new DescriptorValidationException(this, "couldn't build input type descriptor")
+        )
+        .asInstanceOf[Descriptor]
+    )
+  }
+
+  lazy val outputType: ScalaType = {
+    val outputType = asProto.outputType.getOrElse(
+      throw new DescriptorValidationException(this, "missing method output type")
+    )
+
+    ScalaType.Message(
+      FileDescriptor
+        .find(containingService.file, this, outputType)
+        .getOrElse(
+          throw new DescriptorValidationException(this, "couldn't build output type descriptor")
+        )
+        .asInstanceOf[Descriptor]
+    )
+  }
 }
 
 class EnumDescriptor private[descriptors] (

--- a/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/descriptors/Descriptor.scala
@@ -151,28 +151,48 @@ class MethodDescriptor private[descriptors] (
 
   lazy val inputType: Descriptor = {
     val inputType = asProto.inputType.getOrElse(
-      throw new DescriptorValidationException(this, "missing method input type")
+      throw new DescriptorValidationException(
+        this,
+        s"Missing method input type for method $fullName"
+      )
     )
 
-    FileDescriptor
-      .find(containingService.file, this, inputType)
-      .getOrElse(
-        throw new DescriptorValidationException(this, "couldn't build input type descriptor")
-      )
-      .asInstanceOf[Descriptor]
+    FileDescriptor.find(containingService.file, this, inputType) match {
+      case Some(descriptor: Descriptor) => descriptor
+      case Some(otherDescriptor) =>
+        throw new DescriptorValidationException(
+          this,
+          s"Unexpected descriptor type ${otherDescriptor.getClass.getName} for input type $inputType"
+        )
+      case None =>
+        throw new DescriptorValidationException(
+          this,
+          s"Couldn't find descriptor for input type $inputType"
+        )
+    }
   }
 
   lazy val outputType: Descriptor = {
     val outputType = asProto.outputType.getOrElse(
-      throw new DescriptorValidationException(this, "missing method output type")
+      throw new DescriptorValidationException(
+        this,
+        s"Missing method output type for method $fullName"
+      )
     )
 
-    FileDescriptor
-      .find(containingService.file, this, outputType)
-      .getOrElse(
-        throw new DescriptorValidationException(this, "couldn't build output type descriptor")
-      )
-      .asInstanceOf[Descriptor]
+    FileDescriptor.find(containingService.file, this, outputType) match {
+      case Some(descriptor: Descriptor) => descriptor
+      case Some(otherDescriptor) =>
+        throw new DescriptorValidationException(
+          this,
+          s"Unexpected descriptor type ${otherDescriptor.getClass.getName} for output type $outputType"
+        )
+      case None =>
+        throw new DescriptorValidationException(
+          this,
+          s"Couldn't find descriptor for output type $outputType"
+        )
+    }
   }
 }
 


### PR DESCRIPTION
what it says on the tin.

on gitter, there was mention that these fields would maybe be better exposed as `ScalaType` rather than the message descriptor directly. while I don't think this makes a huge difference, I think it makes consuming the endpoint a little more cumbersome. iiuc protobuf method in/out types will always be messages. upcasting to the more general `ScalaType` means calling code will just have to cast back down to `ScalaType.Message` to finally get at the underlying `Descriptor`.

I think a better alternative would be to return the `Descriptor` directly, since afaict wrapping it doesn't add value.
Alternatively, the fields could be typed as `ScalaType.Message` to avoid the up & down casts.