### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ScalaPB
 =======
 
-[![compilerplugin Scala version support](https://index.scala-lang.org/scalapb/scalapb/compilerplugin/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalapb/scalapb/compilerplugin)
+[![ScalaPB runtime version support](https://index.scala-lang.org/scalapb/scalapb/scalapb-runtime/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalapb/scalapb/scalapb-runtime)
 
 [![Join the chat at https://gitter.im/ScalaPB/community](https://badges.gitter.im/ScalaPB/community.svg)](https://gitter.im/ScalaPB/community)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ScalaPB
 =======
 
+[![compilerplugin Scala version support](https://index.scala-lang.org/scalapb/scalapb/compilerplugin/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalapb/scalapb/compilerplugin)
+
 [![Join the chat at https://gitter.im/ScalaPB/community](https://badges.gitter.im/ScalaPB/community.svg)](https://gitter.im/ScalaPB/community)
 
 [![Build Status](https://github.com/scalapb/ScalaPB/workflows/CI/badge.svg)](https://github.com/scalapb/ScalaPB/actions?query=workflow%3ACI)


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `ScalaPB` (and what the latest `ScalaPB` version is for each of those Scala versions):

[![compilerplugin Scala version support](https://index.scala-lang.org/scalapb/scalapb/compilerplugin/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalapb/scalapb/compilerplugin)

More details on the badge format: scalacenter/scaladex#660