### PR TITLE
Avoid warnings about unused values

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/ParseFromGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ParseFromGenerator.scala
@@ -212,7 +212,9 @@ private[compiler] class ParseFromGenerator(
                        |    }""".stripMargin)
             } else p
           }
-          .when(!message.preservesUnknownFields)(_.add("    case tag => _input__.skipField(tag)"))
+          .when(!message.preservesUnknownFields)(
+            _.add("    case tag => _input__.skipField(tag): Unit")
+          )
           .when(message.preservesUnknownFields)(
             _.add(
               """    case tag =>

--- a/proptest/src/test/scala/GenTypes.scala
+++ b/proptest/src/test/scala/GenTypes.scala
@@ -68,11 +68,13 @@ object GenTypes {
     def packable = false
     def isMap    = false
   }
+  object MessageReference extends (Int => ProtoType)
 
   case class EnumReference(id: Int) extends ProtoType {
     def packable = true
     def isMap    = false
   }
+  object EnumReference extends (Int => ProtoType)
 
   case class MapType(keyType: ProtoType, valueType: ProtoType) extends ProtoType {
     def packable = false

--- a/scalapb-runtime/src/main/scala/scalapb/UnknownFieldSet.scala
+++ b/scalapb-runtime/src/main/scala/scalapb/UnknownFieldSet.scala
@@ -89,7 +89,7 @@ object UnknownFieldSet {
           lengthDelimited = lengthDelimited.result()
         )
 
-      def parseField(tag: Int, input: CodedInputStream) = {
+      def parseField(tag: Int, input: CodedInputStream): this.type = {
         val wireType = WireType.getTagWireType(tag)
 
         wireType match {
@@ -106,6 +106,7 @@ object UnknownFieldSet {
               s"Protocol message tag had invalid wire type: ${wireType}"
             )
         }
+        this
       }
     }
 
@@ -135,9 +136,10 @@ object UnknownFieldSet {
       if (fieldBuilders.isEmpty) UnknownFieldSet.empty
       else new UnknownFieldSet(fieldBuilders.view.mapValues(_.result()).toMap)
 
-    def parseField(tag: Int, input: CodedInputStream) = {
+    def parseField(tag: Int, input: CodedInputStream): this.type = {
       val fieldNumber = WireType.getTagFieldNumber(tag)
       fieldBuilders.getOrElseUpdate(fieldNumber, new Field.Builder()).parseField(tag, input)
+      this
     }
   }
 }


### PR DESCRIPTION
Noticed at https://discord.com/channels/632150470000902164/632150470000902166/1115280559023861800

This commit experiments with turning on lints. One change is for builder's mutating method to return `this.type`, which means it doesn't quality as an unconsumed value. `skipField` from Java API is ascribed `: Unit` to fix the inferred type of the match (which was Any or AnyVal) and also indicate that discarding the value was intentional (though Java results don't qualify as unconsumed).

Scala 3 doesn't like using a companion as a function unless it extends function.

Two lints are turned off in test because of ScalaTest style.

MiMA exclusions are added for the `this.type` change, but that could be handled also as `: Unit @nowarn` at use site.