### PR TITLE
Add no_getters generator parameter

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/GeneratorOption.scala
+++ b/compiler-plugin/src/main/scala/scalapb/GeneratorOption.scala
@@ -27,6 +27,10 @@ object GeneratorOption {
     override def toString = "no_lenses"
   }
 
+  case object NoGetters extends GeneratorOption {
+    override def toString = "no_getters"
+  }
+
   case object RetainSourceCodeInfo extends GeneratorOption {
     override def toString = "retain_source_code_info"
   }

--- a/compiler-plugin/src/main/scala/scalapb/compiler/GeneratorParams.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/GeneratorParams.scala
@@ -8,7 +8,8 @@ case class GeneratorParams(
     asciiFormatToString: Boolean = false,
     lenses: Boolean = true,
     retainSourceCodeInfo: Boolean = false,
-    scala3Sources: Boolean = false
+    scala3Sources: Boolean = false,
+    getters: Boolean = true
 )
 
 object GeneratorParams {
@@ -47,7 +48,8 @@ object GeneratorParams {
               Right((params.copy(singleLineToProtoString = true), unrecognized))
             case "ascii_format_to_string" =>
               Right((params.copy(asciiFormatToString = true), unrecognized))
-            case "no_lenses" => Right((params.copy(lenses = false), unrecognized))
+            case "no_lenses"  => Right((params.copy(lenses = false), unrecognized))
+            case "no_getters" => Right((params.copy(getters = false), unrecognized))
             case "retain_source_code_info" =>
               Right((params.copy(retainSourceCodeInfo = true), unrecognized))
             case "scala3_sources" =>

--- a/compiler-plugin/src/main/scala/scalapb/gen.scala
+++ b/compiler-plugin/src/main/scala/scalapb/gen.scala
@@ -34,7 +34,8 @@ object gen {
       singleLineToProtoString: Boolean = false,
       asciiFormatToString: Boolean = false,
       lenses: Boolean = true,
-      scala3Sources: Boolean = false
+      scala3Sources: Boolean = false,
+      getters: Boolean = true
   ): (SandboxedJvmGenerator, Seq[String]) = {
     val optionsBuilder = Set.newBuilder[GeneratorOption]
     if (flatPackage) {
@@ -54,6 +55,9 @@ object gen {
     }
     if (!lenses) {
       optionsBuilder += NoLenses
+    }
+    if (!getters) {
+      optionsBuilder += NoGetters
     }
     if (scala3Sources) {
       optionsBuilder += Scala3Sources

--- a/compiler-plugin/src/test/scala/scalapb/compiler/DefaultOptiocsSpec.scala
+++ b/compiler-plugin/src/test/scala/scalapb/compiler/DefaultOptiocsSpec.scala
@@ -20,6 +20,7 @@ class DefaultOptionsSpec extends AnyFlatSpec with Matchers {
   "grpc" should "be explicitly passed when using GeneratorOptions" in {
     scalapb.gen(Grpc, NoLenses)._2 must contain theSameElementsAs (Seq("grpc", "no_lenses"))
     scalapb.gen(NoLenses)._2 must contain theSameElementsAs (Seq("no_lenses"))
+    scalapb.gen(NoGetters)._2 must contain theSameElementsAs (Seq("no_getters"))
     scalapb.gen(FlatPackage)._2 must contain theSameElementsAs (Seq("flat_package"))
   }
 }

--- a/docs/src/main/markdown/sbt-settings.md
+++ b/docs/src/main/markdown/sbt-settings.md
@@ -76,7 +76,8 @@ scalapb.gen(
   singleLineToProtoString: Boolean = false,
   asciiFormatToString: Boolean = false,
   lenses: Boolean = true,
-  retainSourceCodeInfo: Boolean = false
+  retainSourceCodeInfo: Boolean = false,
+  getters: Boolean = true
 )
 ```
 
@@ -88,5 +89,6 @@ scalapb.gen(
 |`singleLineToProtoString` | `single_line_to_proto_string` | By default, ScalaPB generates a `toProtoString()` method that renders the message as a multi-line format (using `TextFormat.printToUnicodeString`). If set, ScalaPB generates `toString()` methods that use the single line format. |
 |`asciiFormatToString` | `ascii_format_to_string` | Setting this to true, overrides `toString` to return a standard ASCII representation of the message by calling `toProtoString`. |
 |`lenses` | `no_lenses` | By default, ScalaPB generates lenses for each message for easy updating. If you are not using this feature and would like to reduce code size or compilation time, you can set this to `false` and lenses will not be generated. |
+|`getters` | `no_getters` | By default, ScalaPB generates getters for each message. If you are not using this feature, you can set this to `false` and getters will not be generated. |
 | `retainSourceCodeInfo` | `retain_source_code_info` | Retain source code information (locations, comments) provided by protoc in the descriptors. Use the `location` accessor to get that information from a descriptor.|
 | `scala3Sources` | `scala3_sources` | If set, generates sources that are error-free under `-source future` with Scala 3, or `Xsource:3` with Scala 2.13. |

--- a/docs/src/main/markdown/scalapbc.md
+++ b/docs/src/main/markdown/scalapbc.md
@@ -61,7 +61,7 @@ where OPT1,OPT2 is a comma-separated list of options, followed by a colon
 bin/scalapbc my.proto --scala_out=flat_package,java_conversions:protos/src/scala/main/
 ```
 
-The supported parameters are: `flat_package`, `java_conversions`, `grpc` and `single_line_to_proto_string`, `no_lenses`, `retain_source_code_info`.
+The supported parameters are: `flat_package`, `java_conversions`, `grpc` and `single_line_to_proto_string`, `no_lenses`, `no_getters`, `retain_source_code_info`.
 
 Those parameters are described in [SBT settings](sbt-settings.md#additional-options-to-the-generator)
 


### PR DESCRIPTION
If I'm not mistaken, it seems like https://github.com/scalapb/ScalaPB/pull/1140 may have forgotten to expose a generator parameter like `no_lenses` but for getters.

Thank you for working on ScalaPB!