### PR TITLE
Update protobuf to 25.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import BuildHelper._
 import Dependencies._
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
-val protobufCompilerVersion = "3.19.6"
+val protobufCompilerVersion = "3.25.3"
 
 val MimaPreviousVersion = "0.11.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import Keys._
 object Dependencies {
   object versions {
     val grpc                 = "1.62.2"
-    val protobuf             = "3.19.6"
+    val protobuf             = "3.25.3"
     val silencer             = "1.7.16"
     val collectionCompat     = "2.11.0"
     val coursier             = "2.1.9"


### PR DESCRIPTION
Hi. I've fount that ScapaPB relies on quiet old version of the Protobuf. Let's upgrade it unless there is no reasons to keep it