### PR TITLE
Update nscplugin, sbt-scala-native to 0.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 ThisBuild / PB.protocVersion := versions.protobuf
 
 lazy val sharedNativeSettings = List(
-  nativeLinkStubs := true // for utest
+  nativeConfig ~= { _.withLinkStubs(true) } // for utest
 )
 
 lazy val root: Project =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val annotationApi           = "1.3.2"
     val cats                    = "2.6.1"
     val mockito                 = "5.11.0"
-    val munit                   = "1.0.0-M8"
+    val munit                   = "1.0.0-M12"
     val scalaTest               = "3.2.18"
     val scalaTestPlusMockito    = "3.1.0.0"
     val scalaTestPlusScalaCheck = "3.2.18.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val collectionCompat     = "2.12.0"
     val coursier             = "2.1.9"
     val protocGen            = "0.9.7"
-    val protobufRuntimeScala = "0.8.14"
+    val protobufRuntimeScala = "0.8.15"
     val commonsCodec         = "1.16.1"
 
     // For testing

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val grpc                 = "1.63.0"
     val protobuf             = "4.26.0"
     val silencer             = "1.7.16"
-    val collectionCompat     = "2.11.0"
+    val collectionCompat     = "2.12.0"
     val coursier             = "2.1.9"
     val protocGen            = "0.9.7"
     val protobufRuntimeScala = "0.8.14"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 

--- a/test.sh
+++ b/test.sh
@@ -6,8 +6,10 @@ sbt \
     lensesJVM${SCALA_VERSION}/test \
     compilerPluginJVM${SCALA_VERSION}/test \
     runtimeJVM${SCALA_VERSION}/test \
-    grpcRuntimeJVM${SCALA_VERSION}/test \
     proptestJVM${SCALA_VERSION}/test
+
+# grpcRuntimeJVM*/test uses mockito 5.x and requires Java 11
+sbt -java-home ${JAVA_HOME_11_X64} grpcRuntimeJVM${SCALA_VERSION}/test
 
 if [[ $SCALA_VERSION = 2* ]]; then
     sbt \


### PR DESCRIPTION
- Update nscplugin, sbt-scala-native to 0.5.1
- Use `nativeConfig` to enable link stubs

Adapted from #1680
