### PR TITLE
pin to Scala 3.3 (LTS version)

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,8 +1,13 @@
 // https://github.com/scalapb/ScalaPB/commit/d3cc69515ea90f1af7eaf2732d22facb6c9e95e3
 updates.ignore = [
-  { groupId = "com.github.os72", artifactId = "protoc-jar" },
-  { groupId = "com.google.protobuf" },
-  { groupId = "org.scala-lang", artifactId = "scala3-compiler", version = { prefix = "3.1." } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = { prefix = "3.1." } },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = { prefix = "3.1." } }
+  { groupId = "com.github.os72", artifactId = "protoc-jar" }
+  { groupId = "com.google.protobuf" }
 ]
+
+updates.pin = [
+  # Scala 3.3 is the LTS release
+  { groupId = "org.scala-lang", artifactId = "scala3-compiler", version = "3.3." }
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.3." }
+]
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
 
   val Scala213 = "2.13.13"
 
-  val Scala3 = "3.4.2"
+  val Scala3 = "3.3.3"
 
   val silencer = Seq(
     sbt.compilerPlugin(


### PR DESCRIPTION
Scala 3.4 compiled classes won't work with Scala 3.3 runtimes.

I based the scala-steward config on
https://github.com/apache/pekko/blob/main/.scala-steward.conf