### PR TITLE
Update protobuf-java in 0.11.x to 3.25.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import Keys._
 object Dependencies {
   object versions {
     val grpc                 = "1.62.2"
-    val protobuf             = "3.19.6"
+    val protobuf             = "3.25.5"
     val silencer             = "1.7.17"
     val collectionCompat     = "2.12.0"
     val coursier             = "2.1.9"


### PR DESCRIPTION
`3.25.5` is the only version that's not vulnerable to CVE-2024-7254 in 3.x series. I understand that the master is already using 4.x but it'd be great if we could have a 0.11.x series release without the CVE. Thank you.