### PR TITLE
Add information about which required field was missing

### DIFF
--- a/e2e/src/test/scala/NoBoxSpec.scala
+++ b/e2e/src/test/scala/NoBoxSpec.scala
@@ -36,7 +36,7 @@ class NoBoxSpec extends AnyFlatSpec with Matchers {
   "RequiredCar" should "fail validation if required field is missing" in {
     intercept[InvalidProtocolBufferException] {
       RequiredCar.parseFrom(Array.empty[Byte])
-    }.getMessage must be("Message missing required fields.")
+    }.getMessage must be("Message missing required fields: tyre1")
   }
 
   "RequiredCar" should "fail parsing from text if field is empty" in {


### PR DESCRIPTION
Exceptions caused by missing required fields don't mention which fields were missing, even though this information is easy to provide