### PR TITLE
Pass `safe` and `idempotent` options to MethodDescriptor

### DIFF
--- a/e2e-grpc/src/main/protobuf/service.proto
+++ b/e2e-grpc/src/main/protobuf/service.proto
@@ -97,6 +97,10 @@ service Service1 {
   rpc PrimitiveValues(google.protobuf.Int32Value) returns (google.protobuf.StringValue) {};
 
   rpc EchoRequest(Req1) returns (Res6) {}
+
+  rpc NoSideEffects(Req1) returns (Res6) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 service Issue774 {

--- a/e2e-grpc/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
+++ b/e2e-grpc/src/main/scala/com/thesamet/pb/Service1ScalaImpl.scala
@@ -126,4 +126,8 @@ class Service1ScalaImpl extends Service1 {
   }
 
   override def primitiveValues(request: Int): Future[String] = Future.successful("boo")
+
+  override def noSideEffects(request: Req1): Future[Res6] =
+    Future.successful(Res6(Some(request)))
+
 }

--- a/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
+++ b/e2e-grpc/src/test/scala/MethodDescriptorSpec.scala
@@ -7,9 +7,17 @@ import org.scalatest.{LoneElement, OptionValues}
 class MethodDescriptorSpec extends AnyFlatSpec with Matchers with LoneElement with OptionValues {
 
   "scala descriptor" must "expose correct input and output message descriptors" in {
-    val unaryMethod = Service1Grpc.Service1.scalaDescriptor.methods.find(_.name == "CustomUnary").get
+    val unaryMethod =
+      Service1Grpc.Service1.scalaDescriptor.methods.find(_.name == "CustomUnary").get
 
     unaryMethod.inputType must be theSameInstanceAs XYMessage.scalaDescriptor
     unaryMethod.outputType must be theSameInstanceAs Res5.scalaDescriptor
+  }
+
+  "java descriptor" must "set idempotent and safe options when idempotency_level is set" in {
+    val noSideEffMethod = Service1Grpc.METHOD_NO_SIDE_EFFECTS
+
+    noSideEffMethod.isSafe must be(true)
+    noSideEffMethod.isIdempotent must be(true)
   }
 }


### PR DESCRIPTION
Hi! I'm working on the library that provides ConnectRPC-compatible REST interface from ScalaPB service interfaces https://github.com/igor-vovk/connect-rpc-scala. 

One of the nice features of the Connect protocol is being able to expose endpoints so they are reachable with GET-requests instead of POST (https://connectrpc.com/docs/protocol/#unary-get-request). It is controlled by the `idempotency_level` option. This PR adds passing this option to the MethodDefinition, so that https://github.com/igor-vovk/connect-rpc-scala/pull/14/files#diff-c75d247c647e264575f9907d360db7a0769a44833b041a1a540b2eb7592ca656R71 would be possible.
