### PR TITLE
chore: upgrade protobuf-java to 4.28.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import BuildHelper._
 import Dependencies._
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
-val protobufCompilerVersion = "4.28.2"
+val protobufCompilerVersion = "4.28.3"
 
 val MimaPreviousVersion = "0.11.0"
 


### PR DESCRIPTION
Contains fixes from https://github.com/protocolbuffers/protobuf/releases/tag/v28.3