### PR TITLE
chore: upgrade protobuf-java to 4.28.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 ## [1.0.0] (Not yet released)
-- Bump protobuf and protoc to 4.28.2. Currently files must specify proto2 and
+- Bump protobuf and protoc to 4.28.3. Currently files must specify proto2 and
   proto3 syntax. Editions are not supported yet.
 - References to descriptors are fully qualified (#1724)
 - Oneofs are now generated as sealed abstract class instead of sealed traits (#1694)

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import BuildHelper._
 import Dependencies._
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
-val protobufCompilerVersion = "4.28.3"
+val protobufCompilerVersion = Dependencies.versions.protobuf
 
 val MimaPreviousVersion = "0.11.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import Keys._
 object Dependencies {
   object versions {
     val grpc                 = "1.68.2"
-    val protobuf             = "4.28.2"
+    val protobuf             = "4.28.3"
     val silencer             = "1.7.19"
     val collectionCompat     = "2.12.0"
     val coursier             = "2.1.21"


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/releases/tag/v28.3