### PR TITLE
Use Scala 3 threadUnsafe lazy vals

### DIFF
--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -852,6 +852,8 @@ class DescriptorImplicits private[compiler] (
 
     def unrecognizedAnnotationList: Seq[String] =
       deprecatedAnnotation ++ scalaOptions.getUnrecognizedAnnotationsList().asScala.toSeq
+
+    def V: ScalaCompatConstants = enumDescriptor.getFile.V
   }
 
   implicit class ExtendedEnumValueDescriptor(val enumValue: EnumValueDescriptor) {
@@ -1206,9 +1208,13 @@ private[scalapb] class ScalaCompatConstants(emitScala3Sources: Boolean) {
 
   val WithOperator: String = if (emitScala3Sources) " & " else " with "
 
-  val MessageLens =
+  val MessageLens: String =
     if (emitScala3Sources) "_root_.scalapb.lenses.MessageLens"
     else "_root_.scalapb.lenses.ObjectLens"
+
+  val LazyVal: String =
+    if (emitScala3Sources) "@scala.annotation.threadUnsafe lazy val"
+    else "lazy val"
 }
 
 object Helper {

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -86,7 +86,7 @@ class ProtobufGenerator(
       .seq(e.unrecognizedAnnotationList)
       .add(
         s"""final case class Unrecognized(unrecognizedValue: _root_.scala.Int) extends $name(unrecognizedValue) with _root_.scalapb.UnrecognizedEnum
-           |lazy val values: scala.collection.immutable.Seq[ValueType] = scala.collection.immutable.Seq(${e.getValues.asScala
+           |${e.V.LazyVal} values: scala.collection.immutable.Seq[ValueType] = scala.collection.immutable.Seq(${e.getValues.asScala
             .map(_.scalaName.asSymbol)
             .mkString(", ")})
            |def fromValue(__value: _root_.scala.Int): $name = __value match {""".stripMargin
@@ -948,7 +948,7 @@ class ProtobufGenerator(
   )(printer: FunctionalPrinter): FunctionalPrinter = {
     val myFullScalaName = message.scalaType.fullName
     printer
-      .add(s"lazy val defaultInstance = $myFullScalaName(")
+      .add(s"${message.V.LazyVal} defaultInstance = $myFullScalaName(")
       .indent
       .addWithDelimiter(",")(message.fields.collect {
         case field if !field.isInOneof =>
@@ -1131,7 +1131,7 @@ class ProtobufGenerator(
       message: Descriptor
   )(fp: FunctionalPrinter): FunctionalPrinter = {
     val signature =
-      s"lazy val nestedMessagesCompanions: ${message.V.CompSeqType} ="
+      s"${message.V.LazyVal} nestedMessagesCompanions: ${message.V.CompSeqType} ="
     if (message.nestedTypes.isEmpty)
       fp.add(signature + " Seq.empty")
     else
@@ -1147,7 +1147,7 @@ class ProtobufGenerator(
 
   // Finding companion objects for top-level types.
   def generateMessagesCompanions(file: FileDescriptor)(fp: FunctionalPrinter): FunctionalPrinter = {
-    val signature = s"lazy val messagesCompanions: ${file.V.CompSeqType} ="
+    val signature = s"${file.V.LazyVal} messagesCompanions: ${file.V.CompSeqType} ="
     if (file.getMessageTypes.isEmpty)
       fp.add(signature + " Seq.empty")
     else
@@ -1651,10 +1651,14 @@ class ProtobufGenerator(
       s"object ${file.fileDescriptorObject.nameSymbol} extends _root_.scalapb.GeneratedFileObject {"
     ).indent
       .when(file.getDependencies.isEmpty) {
-        _.add("lazy val dependencies: Seq[_root_.scalapb.GeneratedFileObject] = Seq.empty")
+        _.add(
+          s"${file.V.LazyVal} dependencies: Seq[_root_.scalapb.GeneratedFileObject] = Seq.empty"
+        )
       }
       .when(!file.getDependencies.isEmpty) {
-        _.add("lazy val dependencies: Seq[_root_.scalapb.GeneratedFileObject] = Seq(").indent
+        _.add(
+          s"${file.V.LazyVal} dependencies: Seq[_root_.scalapb.GeneratedFileObject] = Seq("
+        ).indent
           .addWithDelimiter(",")(
             file.getDependencies.asScala.map(_.fileDescriptorObject.fullName).toSeq
           )


### PR DESCRIPTION
Hi! 

Scala 3 introduced faster mechanism of initialization for `lazy val`s: [link to docs](https://docs.scala-lang.org/scala3/reference/other-new-features/threadUnsafe-annotation.html). 

I want to propose adding it to some of the lazy val's in the generated outputs.

The reasoning is that there would be no harm if in the worst case scenario default values are initialized more than once and then GCed, but instead there will be a) no thread-locks during the initialization b) much less byte-code and faster compilation, since they are used a lot. Lazy vals for variables inside of the `*Proto` classes (decoding of the protobufs) left as is (no @threadUnsafe annotation added), since it may be more costly to initialize those values more than once.

Here is the example of 2 classes, with annotation and without:
```scala
class LazyVal {
  lazy val x = "test"
}

class ThreadUnsafeLazyVal {
  @scala.annotation.threadUnsafe
  lazy val x = "test"
}
```

It produces the following bytecode (decompiled Java):
```java
/// LazyVal.decompiled.java

import scala.runtime.LazyVals;
import scala.runtime.LazyVals.;

public class LazyVal {
    public static final long OFFSET$0;
    private volatile Object x$lzy1;

    public LazyVal() {
    }

    static {
        OFFSET$0 = .MODULE$.getOffsetStatic(LazyVal.class.getDeclaredField("x$lzy1"));
    }

    public String x() {
        Object var1 = this.x$lzy1;
        if (var1 instanceof String) {
            return (String)var1;
        } else {
            return var1 == scala.runtime.LazyVals.NullValue..MODULE$ ? null : (String)this.x$lzyINIT1();
        }
    }

    private Object x$lzyINIT1() {
        while(true) {
            Object var1 = this.x$lzy1;
            if (var1 == null) {
                if (.MODULE$.objCAS(this, OFFSET$0, (Object)null, scala.runtime.LazyVals.Evaluating..MODULE$)) {
                    Object var2 = null;
                    Object var3 = null;

                    try {
                        var8 = "test";
                        if (var8 == null) {
                            var2 = scala.runtime.LazyVals.NullValue..MODULE$;
                        } else {
                            var2 = var8;
                        }
                    } finally {
                        if (!.MODULE$.objCAS(this, OFFSET$0, scala.runtime.LazyVals.Evaluating..MODULE$, var2)) {
                            LazyVals.Waiting var5 = (LazyVals.Waiting)this.x$lzy1;
                            .MODULE$.objCAS(this, OFFSET$0, var5, var2);
                            var5.countDown();
                        }

                    }

                    return var8;
                }
            } else {
                if (var1 instanceof LazyVals.LazyValControlState) {
                    if (var1 == scala.runtime.LazyVals.Evaluating..MODULE$) {
                        .MODULE$.objCAS(this, OFFSET$0, var1, new LazyVals.Waiting());
                        continue;
                    }

                    if (var1 instanceof LazyVals.Waiting) {
                        ((LazyVals.Waiting)var1).await();
                        continue;
                    }

                    return null;
                }

                return var1;
            }
        }
    }
}

/// ThreadUnsafeLazyVal.decompiled.java

public class ThreadUnsafeLazyVal {
    private String x$lzy2;
    private boolean xbitmap$1;

    public ThreadUnsafeLazyVal() {
    }

    public String x() {
        if (!this.xbitmap$1) {
            this.x$lzy2 = "test";
            this.xbitmap$1 = true;
        }

        return this.x$lzy2;
    }
}

```

What do you think about this change?