### PR TITLE
allow use of deprecated ProtoReflectionService

### DIFF
--- a/e2e-grpc/src/test/scala/GrpcServiceSpecBase.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceSpecBase.scala
@@ -2,7 +2,7 @@ import java.util.concurrent.TimeUnit
 import com.thesamet.pb.{Service1Interceptor, Service1JavaImpl, Service1ScalaImpl}
 import com.thesamet.proto.e2e.service.{Service1Grpc => Service1GrpcScala}
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder, NettyServerBuilder}
-import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.protobuf.services.ProtoReflectionServiceV1
 import io.grpc.stub.StreamObserver
 import io.grpc.{ManagedChannel, Server}
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
@@ -16,7 +16,7 @@ abstract class GrpcServiceSpecBase extends AnyFunSpec with Matchers {
 
   protected[this] final def withScalaServer[T](f: ManagedChannel => T): T = {
     withServer(
-      _.addService(ProtoReflectionService.newInstance())
+      _.addService(ProtoReflectionServiceV1.newInstance())
         .addService(
           Service1GrpcScala.bindService(new Service1ScalaImpl, singleThreadExecutionContext)
         )

--- a/e2e-grpc/src/test/scala/GrpcServiceSpecBase.scala
+++ b/e2e-grpc/src/test/scala/GrpcServiceSpecBase.scala
@@ -2,7 +2,7 @@ import java.util.concurrent.TimeUnit
 import com.thesamet.pb.{Service1Interceptor, Service1JavaImpl, Service1ScalaImpl}
 import com.thesamet.proto.e2e.service.{Service1Grpc => Service1GrpcScala}
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder, NettyServerBuilder}
-import io.grpc.protobuf.services.ProtoReflectionServiceV1
+import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.stub.StreamObserver
 import io.grpc.{ManagedChannel, Server}
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
@@ -14,9 +14,10 @@ import org.scalatest.matchers.must.Matchers
 
 abstract class GrpcServiceSpecBase extends AnyFunSpec with Matchers {
 
+  @scala.annotation.nowarn("cat=deprecation")
   protected[this] final def withScalaServer[T](f: ManagedChannel => T): T = {
     withServer(
-      _.addService(ProtoReflectionServiceV1.newInstance())
+      _.addService(ProtoReflectionService.newInstance())
         .addService(
           Service1GrpcScala.bindService(new Service1ScalaImpl, singleThreadExecutionContext)
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import Keys._
 object Dependencies {
   object versions {
 
-    val grpc                 = "1.68.3"
+    val grpc                 = "1.71.0"
     val protobuf             = "4.28.3"
     val silencer             = "1.7.19"
     val collectionCompat     = "2.13.0"


### PR DESCRIPTION
* see comments in #1830 
* I initially tried to use ProtoReflectionServiceV1 instead of deprecated ProtoReflectionService but one test failed

```
GrpcServiceScalaServerSpec:
[info] scala companion object
[info] - provides descriptor object
[info] scala server
[info]   reflection service
[info]   - listServices *** FAILED ***
[info]     java.util.concurrent.TimeoutException: Futures timed out after [3 seconds]
[info]     at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:269)
[info]     at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:273)
[info]     at scala.concurrent.Await$.$anonfun$result$1(package.scala:223)
[info]     at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:57)
[info]     at scala.concurrent.Await$.result(package.scala:146)
[info]     at GrpcServiceScalaServerSpec.$anonfun$new$6(GrpcServiceScalaServerSpec.scala:56)
[info]     at GrpcServiceSpecBase.$anonfun$withServer$1(GrpcServiceSpecBase.scala:57)
[info]     at GrpcServiceSpecBase.withManagedServer(GrpcServiceSpecBase.scala:63)
[info]     at GrpcServiceSpecBase.withServer(GrpcServiceSpecBase.scala:52)
[info]     at GrpcServiceSpecBase.withScalaServer(GrpcServiceSpecBase.scala:25)
[info]     ...
```

