### PR TITLE
use ubuntu 22 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -136,7 +136,7 @@ jobs:
 
   gh_release:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [native, scalapbc]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub CI won't run ubuntu 20 any more.
Example: https://github.com/scalapb/ScalaPB/actions/runs/15352793795