### PR TITLE
Added Drainable implementation to ProtoInputStream

### DIFF
--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoInputStream.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoInputStream.scala
@@ -1,35 +1,39 @@
 package scalapb.grpc
 
 import com.google.protobuf.CodedOutputStream
+import io.grpc.Drainable
 import scalapb.GeneratedMessage
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ByteArrayInputStream, InputStream, OutputStream}
 
 /** Allows skipping serialization completely when the io.grpc.inprocess.InProcessTransport is used.
   * Inspired by
   * https://github.com/grpc/grpc-java/blob/master/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoInputStream.java
   */
-class ProtoInputStream[T <: GeneratedMessage](msg: T) extends InputStream {
+class ProtoInputStream[T <: GeneratedMessage](msg: T) extends InputStream with Drainable {
 
   private var state: State = Message(msg)
 
-  private sealed trait State {
+  sealed private trait State {
     def message: T = throw new IllegalStateException("message not available")
     def available: Int
     def read(): Int
     def read(b: Array[Byte], off: Int, len: Int): Int
+    def drainTo(target: OutputStream): Int
   }
 
   private object Drained extends State {
     override def available: Int                                = 0
     override def read(): Int                                   = -1
     override def read(b: Array[Byte], off: Int, len: Int): Int = -1
+    override def drainTo(target: OutputStream): Int            = -1
   }
 
   private case class Message(value: T) extends State {
     override def available: Int = value.serializedSize
     override def message: T     = value
     override def read(): Int    = toStream.read()
+
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
       value.serializedSize match {
         case 0 => toDrained.read(b, off, len)
@@ -43,6 +47,12 @@ class ProtoInputStream[T <: GeneratedMessage](msg: T) extends InputStream {
         case _ => toStream.read(b, off, len)
       }
     }
+
+    override def drainTo(target: OutputStream): Int = {
+      value.writeTo(target)
+      available
+    }
+
     private def toStream: State = {
       state = Stream(new ByteArrayInputStream(value.toByteArray))
       state
@@ -57,10 +67,12 @@ class ProtoInputStream[T <: GeneratedMessage](msg: T) extends InputStream {
     override def available: Int                                = value.available()
     override def read(): Int                                   = value.read()
     override def read(b: Array[Byte], off: Int, len: Int): Int = value.read(b, off, len)
+    override def drainTo(target: OutputStream): Int            = value.transferTo(target).toInt
   }
 
   override def read(): Int                                   = state.read()
   override def read(b: Array[Byte], off: Int, len: Int): Int = state.read(b, off, len)
   override def available(): Int                              = state.available
+  override def drainTo(target: OutputStream): Int            = state.drainTo(target)
   def message: T                                             = state.message
 }


### PR DESCRIPTION
The current default output stream that the scalapb marshaller uses does not support the [Drainable interface](https://github.com/grpc/grpc-java/blob/9d5842b8133c87e74b9300751710192231485662/api/src/main/java/io/grpc/Drainable.java#L31) from grpc-java, which becomse a problem [here](https://github.com/grpc/grpc-java/blob/9d5842b8133c87e74b9300751710192231485662/core/src/main/java/io/grpc/internal/MessageFramer.java#L279) where high performance code are expected to support it to avoid copying of the serialized protobuf.

This relatively simple fix allowed us to optimize a performance critical and high throughput service, and after deploying it to production we managed to cut a few GB of heap usage in the runtime and significantly lowered the heap presuure, but we did not get noticible benefit in timings. (Although for bigger protobuf messages it could make the timings a lot better by avoiding the copying)