### PR TITLE
Update grpc-netty, grpc-protobuf, grpc-stub to 1.81.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        java-version: 8
+        java-version: 9
         distribution: temurin
 
     - uses: sbt/setup-sbt@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        java-version: 9
+        java-version: 8
         distribution: temurin
 
     - uses: sbt/setup-sbt@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        java-version: 9
+        java-version: 11
         distribution: temurin
 
     - uses: sbt/setup-sbt@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: 9
         distribution: temurin
 
     - uses: sbt/setup-sbt@v1

--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,13 @@ lazy val grpcRuntime = (projectMatrix in file("scalapb-runtime-grpc"))
       munit.value % "test",
       mockitoCore % "test"
     ),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq("-Wconf:msg=could not find MODULE in enum ElementType:s")
+        case _ => Seq.empty
+      }
+    },
     mimaPreviousArtifacts := Set(
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % MimaPreviousVersion
     )
@@ -281,7 +288,8 @@ lazy val proptest = (projectMatrix in file("proptest"))
           Seq(
             "-Wconf:msg=[Uu]nused&origin=scala[.]collection[.]compat._:s",
             "-Wconf:cat=deprecation&msg=.*[Jj]avaGenerateEqualsAndHash.*deprecated.*:s",
-            "-Wconf:cat=deprecation&msg=.*[dD]eprecatedLegacyJsonFieldConflicts:s"
+            "-Wconf:cat=deprecation&msg=.*[dD]eprecatedLegacyJsonFieldConflicts:s",
+            "-Wconf:msg=could not find MODULE in enum ElementType:s"
           )
         case _ => Seq.empty // Scala 2.12 or other (e.g. pre-2.13)
       }
@@ -340,7 +348,8 @@ val e2eCommonSettings = commonSettings ++ Seq(
           "-Wconf:cat=deprecation&src=.*CustomAnnotationProto.scala.*:s",
           "-Wconf:cat=deprecation&src=.*TestDeprecatedFields.scala.*:s",
           "-Wconf:cat=deprecation&origin=.*ServerReflectionProto.*:s",
-          "-Wconf:msg=Unused import:s,origin=com.thesamet.proto.e2e.custom_options_use.FooMessage:s"
+          "-Wconf:msg=Unused import:s,origin=com.thesamet.proto.e2e.custom_options_use.FooMessage:s",
+          "-Wconf:msg=could not find MODULE in enum ElementType:s"
         )
       case _ => Seq.empty
     }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val MimaPreviousVersion = "0.11.0"
 inThisBuild(
   List(
     scalaVersion := Scala212,
-    javacOptions ++= List("--release", "9"),
+    javacOptions ++= List("-target", "8", "-source", "8"),
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     ConsoleHelper.welcomeMessage
   )

--- a/build.sbt
+++ b/build.sbt
@@ -139,13 +139,6 @@ lazy val grpcRuntime = (projectMatrix in file("scalapb-runtime-grpc"))
       munit.value % "test",
       mockitoCore % "test"
     ),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq("-Wconf:msg=could not find MODULE in enum ElementType:s")
-        case _ => Seq.empty
-      }
-    },
     mimaPreviousArtifacts := Set(
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % MimaPreviousVersion
     )
@@ -288,8 +281,7 @@ lazy val proptest = (projectMatrix in file("proptest"))
           Seq(
             "-Wconf:msg=[Uu]nused&origin=scala[.]collection[.]compat._:s",
             "-Wconf:cat=deprecation&msg=.*[Jj]avaGenerateEqualsAndHash.*deprecated.*:s",
-            "-Wconf:cat=deprecation&msg=.*[dD]eprecatedLegacyJsonFieldConflicts:s",
-            "-Wconf:msg=could not find MODULE in enum ElementType:s"
+            "-Wconf:cat=deprecation&msg=.*[dD]eprecatedLegacyJsonFieldConflicts:s"
           )
         case _ => Seq.empty // Scala 2.12 or other (e.g. pre-2.13)
       }
@@ -348,8 +340,7 @@ val e2eCommonSettings = commonSettings ++ Seq(
           "-Wconf:cat=deprecation&src=.*CustomAnnotationProto.scala.*:s",
           "-Wconf:cat=deprecation&src=.*TestDeprecatedFields.scala.*:s",
           "-Wconf:cat=deprecation&origin=.*ServerReflectionProto.*:s",
-          "-Wconf:msg=Unused import:s,origin=com.thesamet.proto.e2e.custom_options_use.FooMessage:s",
-          "-Wconf:msg=could not find MODULE in enum ElementType:s"
+          "-Wconf:msg=Unused import:s,origin=com.thesamet.proto.e2e.custom_options_use.FooMessage:s"
         )
       case _ => Seq.empty
     }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val MimaPreviousVersion = "0.11.0"
 inThisBuild(
   List(
     scalaVersion := Scala212,
-    javacOptions ++= List("-target", "8", "-source", "8"),
+    javacOptions ++= List("--release", "9"),
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     ConsoleHelper.welcomeMessage
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import Keys._
 
 object Dependencies {
   object versions {
-    val grpc                 = "1.75.0"
+    val grpc                 = "1.81.0"
     val protobuf             = "4.32.0"
     val collectionCompat     = "2.13.0"
     val coursier             = "2.1.24"


### PR DESCRIPTION
This PR adds scalac option to suppress jspecify annotation parsing error. This was preventing grpc bump PRs created by scala-steward from building (e.g. #2104)